### PR TITLE
update ruff.toml

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -182,7 +182,11 @@ keep-runtime-typing = true
 max-complexity = 25
 
 [lint.per-file-ignores]
-"tests/*" = ["S101"]
+"tests/*" = [
+"I001",
+"S101",
+"TID251",
+]
 
 [lint.pydocstyle]
 property-decorators = ["propcache.api.cached_property"]


### PR DESCRIPTION
## Summary by Sourcery

Refine and extend the Ruff configuration for stricter and more precise linting

Enhancements:
- Replace the generic "ALL" select list with explicit rule codes across multiple plugins
- Expand and update the ignore list to align with formatter compatibility and project conventions
- Introduce plugin-specific settings for flake8-pytest-style, flake8-tidy-imports, isort, and pydocstyle
- Add per-file ignore rules for test files and adjust mccabe and pyupgrade parameters