### PR TITLE
Create releases.yml

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,29 @@
+name: "Release"
+
+on:
+  release:
+    types:
+      - "published"
+
+permissions: {}
+
+jobs:
+  release:
+    name: "Release"
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: write
+    steps:
+      - name: "Checkout the repository"
+        uses: "actions/checkout@v4.1.7"
+
+      - name: "ZIP the integration directory"
+        shell: "bash"
+        run: |
+          cd "${{ github.workspace }}/custom_components/utility_meter_next_gen"
+          zip utility_meter_next_gen.zip -r ./
+
+      - name: "Upload the ZIP file to the release"
+        uses: "softprops/action-gh-release@v2.0.8"
+        with:
+          files: ${{ github.workspace }}/custom_components/utility_meter_next_gen/utility_meter_next_gen.zip


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

## Summary by Sourcery

Add a GitHub Actions workflow to package and upload the utility_meter_next_gen integration as a ZIP artifact when a release is published

CI:
- Introduce .github/workflows/releases.yml triggered on release publication
- Zip the custom_components/utility_meter_next_gen directory
- Upload the generated ZIP file to the GitHub release using softprops/action-gh-release