### PR TITLE
Bug Fix

### DIFF
--- a/custom_components/utility_meter_next_gen/manifest.json
+++ b/custom_components/utility_meter_next_gen/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/cabberley/utility_meter_evolved/issues",
   "requirements": ["cronsim==2.6"],
   "ssdp": [],
-  "version": "2025.7.3",
+  "version": "2025.7.5",
   "zeroconf": []
 }

--- a/custom_components/utility_meter_next_gen/sensor.py
+++ b/custom_components/utility_meter_next_gen/sensor.py
@@ -992,8 +992,7 @@ class UtilityMeterCalculatedSensor(RestoreSensor):
         """Handle the sensor state changes."""
         new_state = event.data["new_state"]
         _LOGGER.debug("Received new state: %s", new_state)
-        _LOGGER.debug("Received new state.state: %s", new_state.state)
-
+        
         self._attr_available = True #new_state #!= STATE_UNAVAILABLE
 
         self._attr_native_value = None


### PR DESCRIPTION
# Proposed Changes

> Sensor Bug Fix

## Related Issues

## Summary by Sourcery

Remove erroneous debug logging in the sensor state listener and update the component version to 2025.7.5.

Bug Fixes:
- Remove redundant debug statement referencing new_state.state in the sensor state listener to prevent attribute errors.

Chores:
- Bump component version to 2025.7.5.