### PR TITLE
Multi Predefined recycle Meters Feature Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,15 @@ This custom HACS integration for Home Assistant provides an enhanced set of capa
 
 Based on the current "Utility Meter" component code in the Home-Assistant/Core. Acknowledgements to [DGomes](https://github.com/dgomes) who is the Code Owner of the core utlity Meter who really did all the hard logic work for the Meter Utility.
 
-The main enhancements that the Utility Meter Next Gen has added to the original Utility Meter include:
+There are lots of enhancements that the Utility Meter Next Gen has added to the original Utility Meter include:
 
+- **Create multiple period sensors, optionally with Tariffs and individual Calculation sensors from a single Source and Calculation Sensor**
 - Creating Cron schedule patterns via the Frontend of HA, you no longer need to create them in configuration.yaml!
 - Additional Predefined schedules that should accomodate the majority of people's needs.
 - The addition of an optional secondary sensor/entity that will be used to calculate a value based on the Meters value.
 - Option to create an additional Sensor for the Calculated Value, if you have added a sensor to create a calculated value.
 - All settings of the Meter can be modified through the Frontend. The options reflect the schedule type you created the Meter with (Predefined or CRON).
-- An option to create a "Total" Tariff that will not pause like a normal Tariff does. (You can create a sungle Sensor set that collects for each tariff period plus the total)
+- An option to create a "Total" Tariff that will not pause like a normal Tariff does. (You can create a single Sensor set that collects for each tariff period plus the total)
 - Additional extra attributes have been added to the Sensor, so you can see quickly the key information about the sensor and what it is doing.
 - Additional attributes that don't change are not recorded in thhe Recorder DB to avoid unnecessary recorder data bloat.
 - Calibration values can now be set and modified through the Utility Meter configuration.
@@ -43,13 +44,16 @@ These enhancements should provide a very versatile solution to simplify creating
 
 ## Installation
 
-Add this [repository](https://github.com/cabberley/utility_meter_evolved) via your custom Repositories option in the HACS dashboard as an "Integration Type" and then find "Utility Meter Next Gen" in the repository list, download and restart your Home Assistant.
+**The Utility Meter Next Gen is now available directly from HACS, no need to add the repository anymore!!**
 
-Or preferably easier use the link below to add it to your system:
+Go to the HACS Dashboard in your Home Assistant, and search for "Utility Meter Next Gen", download and restart your HA.
+
+OR
+
+1. Add this [repository](https://github.com/cabberley/utility_meter_evolved) via your custom Repositories option in the HACS dashboard as an "Integration Type" and then find "Utility Meter Next Gen" in the repository list, download and restart your Home Assistant.
+2. Use the link below to add it to your system:
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=cabberley&repository=utility_meter_evolved&category=integration)
-
-> **NOTE: Currently waiting for this new integration to be added to the HACS repository of Custom Integrations.**
 
 ## Using the Utility Meter Next Gen
 
@@ -57,11 +61,31 @@ After installing the integration, you should now find **Utility Meter Next Gen**
 
 Follow the instructions to setup your new Meter with an optional Caculation Sensor.
 
+## Using the Multi Predefined reset cycle Meters
+
+This great new feature will take the pain away from setting multiple individual Meters to track your usuage and $$. If you like to track your meters for various periods like every 5 minutes, 30 minutes, hourly, daily, monthly or yearly, this feature enables you to create a single config that will deliver:
+
+- Individual sensors for each time period.
+- Individual Tariff based sensors for each tariff for each time period.
+- Create a separate Calculation Sensor for every Meter created.
+- A single Select for the tariff selection that will pause/collect all the sensors in alignment with your Select choice.
+- After creation, you can go back and change (add/remove) Predefiend Reset Cycles and if you created a Tariff based set change the list of Tariffs. You can also add or remove the Calculation Sensor if you created a Utility Meter with a Calculation source.
+
+In addition to all of that, this special Multiple sensor config, always you to calibrate one of those periods. For example, those that are tracking their daily energy costs, may have a daily "service/connection" charge. With this Config, you can tell the setup to only apply the calibration calculation value to just the "Daily" meter.
+
+When you create a new Utlity Meter using the new "Multi Predefined reset cycle Meters", it is very similar to creating a normal predefined recycle Meter with a few additional options.
+
+1. After choosing your Source Sensors, you are then presented with the next step, select the various time periods you would like meters for. You can choose 1 or choose them all!
+2. After submitting the Predefined list you are then able to optional add some other more granular settings.
+3. The settings will be familiar to the normal Predefined Recycle Meter with the following changes:
+   1. For both the calibration sensors there is a new option to select which of the predefined cycles to apply it to.
+   2. For simplicity, the ability to set an Offset to the recycle times has been removed.
+
 ## Some Additional helpers
 
 ### Warning
 
-**Do not change the "Entity ID" after creating your meter, it will break the Sennors that this integration creates**
+**Do not change the "Entity ID" after creating your meter, it will break the Sensors that this integration creates**
 
 ### Selection of Sensors to Monitor
 
@@ -101,6 +125,3 @@ A good example of using the calibration sensor is if you are tracking the Cost o
 - if your Consumption is being recorded as MWh and your Calculation Sensor is $/kWh then you want to convert your MWh to kWH to achieve this the multiplier should be set to 1000.
 - if your Consumption is being recorded as Wh and your Calculation Sensor is $/kWh then you want to convert your MWh to kWH to achieve this the multiplier should be set to 0.0001.
 
-### If you want to track one of the attributes like "Last period calculated value" as a Sensor?
-
-If you want to track via another sensor the calculated attribute variable, I would suggest another Great HACS Custom Integration written by gjohansson-ST [Attribute as Sensor](https://github.com/gjohansson-ST/attribute_as_sensor) this integration can monitor an attribute in the Utility Meter Next Gen and surface it as a Sensor in its own right.

--- a/custom_components/utility_meter_next_gen/__init__.py
+++ b/custom_components/utility_meter_next_gen/__init__.py
@@ -27,6 +27,8 @@ from homeassistant.helpers.helper_integration import (
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
+    CONF_CONFIG_CALIBRATE_APPLY,
+    CONF_CONFIG_CALIBRATE_CALC_APPLY,
     CONF_CONFIG_CALIBRATE_CALC_VALUE,
     CONF_CONFIG_CALIBRATE_VALUE,
     CONF_CREATE_CALCULATION_SENSOR,
@@ -58,6 +60,7 @@ _LOGGER = logging.getLogger(__name__)
 def validate_cron_pattern(pattern):
     """Check that the pattern is well-formed."""
     try:
+        _LOGGER.debug("Testing cron pattern: %s", pattern)
         CronSim(pattern, datetime(2020, 1, 1))  # any date will do
     except CronSimError as err:
         _LOGGER.error("Invalid cron pattern %s: %s", pattern, err)
@@ -85,7 +88,8 @@ METER_CONFIG_SCHEMA = vol.Schema(
             vol.Optional(CONF_NAME): cv.string,
             vol.Optional(CONF_UNIQUE_ID): cv.string,
             vol.Optional(CONF_METER_TYPE): vol.In(CONF_METER_TYPES),
-            vol.Optional(CONF_METER_OFFSET, default=CONF_METER_OFFSET_DURATION_DEFAULT): cv.ensure_list,
+            vol.Optional(CONF_METER_OFFSET,
+                default=CONF_METER_OFFSET_DURATION_DEFAULT): cv.ensure_list,
             vol.Optional(CONF_METER_DELTA_VALUES, default=False): cv.boolean,
             vol.Optional(CONF_METER_NET_CONSUMPTION, default=False): cv.boolean,
             vol.Optional(CONF_METER_PERIODICALLY_RESETTING, default=True): cv.boolean,
@@ -291,22 +295,37 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 
     _LOGGER.info("Migration to version %s successful", config_entry.version)
 
-    if config_entry.version == 3 or config_entry.version is None:
+    if config_entry.version == 3:
         new = {**config_entry.options, CONF_CONFIG_CALIBRATE_CALC_VALUE: 0}
         new = {**config_entry.options, CONF_CONFIG_CALIBRATE_VALUE: 0}
         hass.config_entries.async_update_entry(config_entry, options=new, version=4)
 
     _LOGGER.info("Migration to version %s successful", config_entry.version)
 
-    if config_entry.version == 4 or config_entry.version is None:
+    if config_entry.version == 4:
         new = {**config_entry.options, CONF_CONFIG_CALIBRATE_CALC_VALUE: 0}
         hass.config_entries.async_update_entry(config_entry, options=new, version=5)
 
     _LOGGER.info("Migration to version %s successful", config_entry.version)
 
-    if config_entry.version == 5 or config_entry.version is None:
-        new = {**config_entry.options, CONF_CREATE_CALCULATION_SENSOR: CONF_CREATE_CALCULATION_SENSOR_DEFAULT}
+    if config_entry.version == 5:
+        new = {**config_entry.options,
+               CONF_CREATE_CALCULATION_SENSOR: CONF_CREATE_CALCULATION_SENSOR_DEFAULT}
         hass.config_entries.async_update_entry(config_entry, options=new, version=6)
+
+    _LOGGER.info("Migration to version %s successful", config_entry.version)
+
+    if config_entry.version == 6:
+        new = {**config_entry.options,
+               CONF_CONFIG_CALIBRATE_CALC_APPLY: None}
+        hass.config_entries.async_update_entry(config_entry, options=new, version=7)
+
+    _LOGGER.info("Migration to version %s successful", config_entry.version)
+
+    if config_entry.version == 7:
+        new = {**config_entry.options,
+               CONF_CONFIG_CALIBRATE_APPLY: None}
+        hass.config_entries.async_update_entry(config_entry, options=new, version=8)
 
     _LOGGER.info("Migration to version %s successful", config_entry.version)
 

--- a/custom_components/utility_meter_next_gen/config_flow.py
+++ b/custom_components/utility_meter_next_gen/config_flow.py
@@ -113,7 +113,7 @@ class UtilityMeterEvolvedCustomConfigFlow(ConfigFlow, domain=DOMAIN):
                     return await self.async_step_cron()
                 elif user_input.get(CONF_CONFIG_TYPE) == CONF_CONFIG_PREDEFINED:  # noqa: RET505
                     return await self.async_step_predefined()
-                elif user_input.get(CONF_CONFIG_TYPE) == CONF_CONFIG_MULTI:  # noqa: RET505
+                elif user_input.get(CONF_CONFIG_TYPE) == CONF_CONFIG_MULTI:
                     return await self.async_step_multi_step_1()
                 #return await self.async_step_repo()
 
@@ -258,8 +258,7 @@ class OptionsFlowHandler(OptionsFlow):
         """Initialize the options flow handler."""
         self.options_schema =None
         self.config_type = None
-        #self.config_entry = config_entry
-        self.data = config_entry.options.copy()  # type: ignore
+        self.data = config_entry.options.copy()  #noqa: PGH003 # type: ignore
         _LOGGER.debug("async Option init self.data: %s", self.data)
         if config_entry.options["config_type"] == CONF_CONFIG_CRON:
             self.config_type = CONF_CONFIG_CRON

--- a/custom_components/utility_meter_next_gen/config_flow.py
+++ b/custom_components/utility_meter_next_gen/config_flow.py
@@ -4,18 +4,22 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal, DecimalException
+import logging
 from typing import Any, Optional
 
 from cronsim import CronSim, CronSimError
 
-from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import callback
 
 from .const import (
+    CONF_CONFIG_CALIBRATE_APPLY,
+    CONF_CONFIG_CALIBRATE_CALC_APPLY,
     CONF_CONFIG_CALIBRATE_CALC_VALUE,
     CONF_CONFIG_CALIBRATE_VALUE,
     CONF_CONFIG_CRON,
+    CONF_CONFIG_MULTI,
     CONF_CONFIG_PREDEFINED,
     CONF_CONFIG_TYPE,
     CONF_CREATE_CALCULATION_SENSOR,
@@ -34,20 +38,24 @@ from .schemas import (
     BASE_CONFIG_SCHEMA,
     create_cron_config_schema,
     create_cron_option_schema,
+    create_multi_config_schema_step_1,
+    create_multi_config_schema_step_2,
+    create_multi_option_schema_step_2,
     create_predefined_config_schema,
     create_predefined_option_schema,
 )
 
+_LOGGER = logging.getLogger(__name__)
 
 async def validate():
     """Validate the configuration."""
     # This function can be extended to include any validation logic needed.
     return True
 
-class UtilityMeterEvolvedCustomConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class UtilityMeterEvolvedCustomConfigFlow(ConfigFlow, domain=DOMAIN):
     """Github Custom config flow."""
 
-    VERSION = 6
+    VERSION = 8
 
     data: Optional[dict[str, Any]]  # noqa: UP045
 
@@ -105,6 +113,8 @@ class UtilityMeterEvolvedCustomConfigFlow(config_entries.ConfigFlow, domain=DOMA
                     return await self.async_step_cron()
                 elif user_input.get(CONF_CONFIG_TYPE) == CONF_CONFIG_PREDEFINED:  # noqa: RET505
                     return await self.async_step_predefined()
+                elif user_input.get(CONF_CONFIG_TYPE) == CONF_CONFIG_MULTI:  # noqa: RET505
+                    return await self.async_step_multi_step_1()
                 #return await self.async_step_repo()
 
         return self.async_show_form(
@@ -124,6 +134,8 @@ class UtilityMeterEvolvedCustomConfigFlow(config_entries.ConfigFlow, domain=DOMA
 
             if not errors:
                 # Input is valid, set data.
+                self.data[CONF_CONFIG_CALIBRATE_APPLY] = None
+                self.data[CONF_CONFIG_CALIBRATE_CALC_APPLY] = None
                 self.data[CONF_CONFIG_CALIBRATE_CALC_VALUE] = 0
                 self.data[CONF_CONFIG_CALIBRATE_VALUE] = 0
                 self.data[CONF_CREATE_CALCULATION_SENSOR] = CONF_CREATE_CALCULATION_SENSOR_DEFAULT
@@ -157,6 +169,8 @@ class UtilityMeterEvolvedCustomConfigFlow(config_entries.ConfigFlow, domain=DOMA
 
             if not errors:
                 # Input is valid, set data.
+                self.data[CONF_CONFIG_CALIBRATE_APPLY] = None
+                self.data[CONF_CONFIG_CALIBRATE_CALC_APPLY] = None
                 self.data[CONF_CONFIG_CALIBRATE_CALC_VALUE] = 0
                 self.data[CONF_CONFIG_CALIBRATE_VALUE] = 0
                 self.data[CONF_CONFIG_CRON] = None  # noqa: PGH003 # type: ignore
@@ -172,25 +186,93 @@ class UtilityMeterEvolvedCustomConfigFlow(config_entries.ConfigFlow, domain=DOMA
             data_schema=create_predefined_config_schema(self.data),
             errors=errors
         )
+
+    async def async_step_multi_step_1(self, user_input:
+            Optional[dict[str, Any]] = None):  # noqa: UP045
+        """Second step in config flow to add a repo to watch."""
+        errors: dict[str, str] = {}
+        self.data = self.data or {}  # Initialize data if not set
+        if user_input is not None:
+            # Validate the path.
+            try:
+                await validate()
+
+            except ValueError:
+                errors["base"] = "invalid_path"
+
+            if not errors:
+                # Input is valid, set data.
+                self.data[CONF_METER_OFFSET] = CONF_METER_OFFSET_DURATION_DEFAULT
+                self.data[CONF_CONFIG_CALIBRATE_CALC_VALUE] = 0
+                self.data[CONF_CONFIG_CALIBRATE_VALUE] = 0
+                self.data[CONF_CONFIG_CRON] = None  # noqa: PGH003 # type: ignore
+                self.data[CONF_CREATE_CALCULATION_SENSOR] = CONF_CREATE_CALCULATION_SENSOR_DEFAULT
+                self.data[CONF_SOURCE_CALC_MULTIPLIER] = 1
+                self.data[CONF_TARIFFS] = []  # noqa: PGH003 # type: ignore
+                self.data.update(user_input)  # noqa: PGH003 # type: ignore
+                return await self.async_step_multi_step_2()
+
+        return self.async_show_form(
+            step_id="multi_step_1",
+            data_schema=create_multi_config_schema_step_1(self.data),
+            errors=errors
+        )
+    async def async_step_multi_step_2(self, user_input:
+            Optional[dict[str, Any]] = None):  # noqa: UP045
+        """Second step in config flow to add a repo to watch."""
+        errors: dict[str, str] = {}
+        self.data = self.data or {}  # Initialize data if not set
+        if user_input is not None:
+            # Validate the path.
+            try:
+                await validate()
+
+            except ValueError:
+                errors["base"] = "invalid_path"
+
+            if not errors:
+                # Input is valid, set data.
+                if user_input[CONF_CONFIG_CALIBRATE_APPLY] == "none":
+                    user_input[CONF_CONFIG_CALIBRATE_APPLY] = None
+                if user_input[CONF_CONFIG_CALIBRATE_CALC_APPLY] == "none":
+                    user_input[CONF_CONFIG_CALIBRATE_CALC_APPLY] = None
+                self.data.update(user_input)  # noqa: PGH003 # type: ignore
+                return self.async_create_entry(title=self.data["name"],    # noqa: PGH003 # type: ignore
+                            data={}, options=self.data)
+
+        return self.async_show_form(
+            step_id="multi_step_2",
+            data_schema=create_multi_config_schema_step_2(self.data),
+            errors=errors
+        )
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
         return OptionsFlowHandler(config_entry)
 
-
-class OptionsFlowHandler(config_entries.OptionsFlow):
+class OptionsFlowHandler(OptionsFlow):
     """Handles options flow for the component."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+    def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize the options flow handler."""
-        #self.config_entry = config_entry
         self.options_schema =None
-
+        self.config_type = None
+        #self.config_entry = config_entry
+        self.data = config_entry.options.copy()  # type: ignore
+        _LOGGER.debug("async Option init self.data: %s", self.data)
         if config_entry.options["config_type"] == CONF_CONFIG_CRON:
+            self.config_type = CONF_CONFIG_CRON
+            # Create the options schema for cron config.
             self.options_schema = create_cron_option_schema(config_entry.options)
-        else:
+        elif config_entry.options["config_type"] == CONF_CONFIG_PREDEFINED:
+            self.config_type = CONF_CONFIG_PREDEFINED
+            # Create the options schema for predefined config.
             self.options_schema = create_predefined_option_schema(config_entry.options)
+        elif config_entry.options["config_type"] == CONF_CONFIG_MULTI:
+            self.config_type = CONF_CONFIG_MULTI
+            # Create the options schema for multi config.
+            self.options_schema = create_multi_option_schema_step_2(config_entry.options)
 
     @staticmethod
     def _validate_state(state: State | None) -> Decimal | None: # noqa: F821
@@ -203,6 +285,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             )
         except DecimalException:
             return None
+
 
     async def async_step_init(
         self, user_input = None
@@ -233,18 +316,63 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     user_input[CONF_CREATE_CALCULATION_SENSOR] = False
             except DecimalException:
                 errors["base"] = "source_calc_sensor_not_a_number"
-            if self.config_entry.options[CONF_TARIFFS] == [] or self.config_entry.options[CONF_TARIFFS] is None:
+            _LOGGER.debug("Option self.data: %s", self)
+            _LOGGER.debug("Option user_input: %s", user_input)
+            ###Issues here somehow
+            if self.data[CONF_TARIFFS] == [] or self.data is None:
                 user_input[CONF_TARIFFS] = []
-            if self.config_entry.options["config_type"] == CONF_CONFIG_CRON:
+            if self.data["config_type"] == CONF_CONFIG_CRON:
+                user_input[CONF_CONFIG_CALIBRATE_APPLY] = None
+                user_input[CONF_CONFIG_CALIBRATE_CALC_APPLY] = None
                 user_input[CONF_CONFIG_TYPE] = CONF_CONFIG_CRON
                 user_input[CONF_METER_OFFSET] =CONF_METER_OFFSET_DURATION_DEFAULT
                 user_input[CONF_METER_TYPE] = None
-            else:
+            elif self.data["config_type"] == CONF_CONFIG_PREDEFINED:
+                user_input[CONF_CONFIG_CALIBRATE_APPLY] = None
+                user_input[CONF_CONFIG_CALIBRATE_CALC_APPLY] = None
                 user_input[CONF_CONFIG_CRON] = None
                 user_input[CONF_CONFIG_TYPE] = CONF_CONFIG_PREDEFINED
+            elif self.data["config_type"] == CONF_CONFIG_MULTI:
+                user_input[CONF_CONFIG_CRON] = None
+                user_input[CONF_CONFIG_TYPE] = CONF_CONFIG_MULTI
+                user_input[CONF_METER_OFFSET] = CONF_METER_OFFSET_DURATION_DEFAULT
+                #user_input[CONF_TARIFFS] = []  # noqa: PGH003 # type: ignore
 
+            _LOGGER.debug("async Option step 1 self.data: %s", self.data)
+
+            #if self.data["config_type"] == CONF_CONFIG_MULTI:
+            #    return await self.async_multi_option_step_2()
+
+            _LOGGER.debug("async Option NOT MULTI: %s", self.data["config_type"])
             return self.async_create_entry(title=self.config_entry.title, data=user_input)
+            # For multi config, we need to show the next step.
+            #self.data = user_input
+            #return await self.async_multi_step_2()
         #options_schema = OPTIONS_SCHEMA
+        _LOGGER.debug("async Option init schema: %s", self.options_schema)
         return self.async_show_form(
-            step_id="init", data_schema=self.options_schema, errors=errors
+            step_id="init",
+            data_schema=self.options_schema,
+            errors=errors
+        )
+
+    async def async_multi_option_step_2(self, user_input = None):
+        """Second step in config flow to add a repo to watch."""
+        #errors: dict[str, str] = {}
+        #self.data = self.data or {}  # Initialize data if not set
+        _LOGGER.debug("async Option step 2 self.data: %s", self.data)
+        if user_input is not None:
+            # Validate the path.
+            await validate()
+
+            # Input is valid, set data.
+            self.data.update(user_input)  # noqa: PGH003 # type: ignore
+            return self.async_create_entry(
+                title=self.config_entry.title,
+                data=self.data
+            )
+        _LOGGER.debug("async Option step 2 schema: %s", create_multi_option_schema_step_2(self.data))
+        return self.async_show_form(
+            step_id="init_2",
+            data_schema=create_multi_option_schema_step_2(self.data)
         )

--- a/custom_components/utility_meter_next_gen/const.py
+++ b/custom_components/utility_meter_next_gen/const.py
@@ -2,7 +2,24 @@
 
 DOMAIN = "utility_meter_next_gen"
 
+METER_NAME_EVERY_FIVE_MINUTES = "5 Minute"
+METER_NAME_EVERY_TEN_MINUTES = "10 Minute"
+METER_NAME_EVERY_TWENTY_MINUTES = "20 Minute"
+METER_NAME_HALF_HOURLY = "30 Minute"
+METER_NAME_QUARTER_HOURLY = "15 Minute"
+METER_NAME_HOURLY = "Hourly"
+METER_NAME_DAILY = "Daily"
+METER_NAME_WEEKLY = "Weekly"
+METER_NAME_MONTHLY = "Monthly"
+METER_NAME_BIMONTHLY = "Bi Monthly"
+METER_NAME_QUARTERLY = "Quarterly"
+METER_NAME_HALF_YEARLY = "Half Yearly"
+METER_NAME_YEARLY = "Yearly"
+
+# Meter types
 EVERY_FIVE_MINUTES = "every-five-minutes"
+EVERY_TEN_MINUTES = "every-ten-minutes"
+EVERY_TWENTY_MINUTES = "every-twenty-minutes"
 HALF_HOURLY = "half-hourly"
 QUARTER_HOURLY = "quarter-hourly"
 HOURLY = "hourly"
@@ -14,10 +31,47 @@ QUARTERLY = "quarterly"
 HALF_YEARLY = "half-yearly"
 YEARLY = "yearly"
 
+# Meter type names
+METER_NAME_TYPES = {
+    EVERY_FIVE_MINUTES: METER_NAME_EVERY_FIVE_MINUTES,
+    EVERY_TEN_MINUTES: METER_NAME_EVERY_TEN_MINUTES,
+    QUARTER_HOURLY: METER_NAME_QUARTER_HOURLY,
+    EVERY_TWENTY_MINUTES: METER_NAME_EVERY_TWENTY_MINUTES,
+    HALF_HOURLY: METER_NAME_HALF_HOURLY,
+    HOURLY: METER_NAME_HOURLY,
+    DAILY: METER_NAME_DAILY,
+    WEEKLY: METER_NAME_WEEKLY,
+    MONTHLY: METER_NAME_MONTHLY,
+    BIMONTHLY: METER_NAME_BIMONTHLY,
+    QUARTERLY: METER_NAME_QUARTERLY,
+    HALF_YEARLY: METER_NAME_HALF_YEARLY,
+    YEARLY: METER_NAME_YEARLY,
+}
+# List of meter types
+# This list is used to validate the meter type in the configuration.
+# It should match the keys in METER_NAME_TYPES.
+# The order of the list is important for the UI display.
 METER_TYPES = [
     "none",
     EVERY_FIVE_MINUTES,
+    EVERY_TEN_MINUTES,
     QUARTER_HOURLY,
+    EVERY_TWENTY_MINUTES,
+    HALF_HOURLY,
+    HOURLY,
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+    BIMONTHLY,
+    QUARTERLY,
+    HALF_YEARLY,
+    YEARLY,
+]
+MULTI_METER_TYPES = [
+    EVERY_FIVE_MINUTES,
+    EVERY_TEN_MINUTES,
+    QUARTER_HOURLY,
+    EVERY_TWENTY_MINUTES,
     HALF_HOURLY,
     HOURLY,
     DAILY,
@@ -38,10 +92,12 @@ PAUSED = "paused"
 SINGLE_TARIFF = "single_tariff"
 TOTAL_TARIFF = "total"
 
-
+CONF_CONFIG_CALIBRATE_APPLY = "calibrate_apply"
+CONF_CONFIG_CALIBRATE_CALC_APPLY = "calibrate_calc_apply"
 CONF_CONFIG_CALIBRATE_CALC_VALUE = "calibrate_calc_value"
 CONF_CONFIG_CALIBRATE_VALUE = "calibrate_value"
 CONF_CONFIG_CRON = "cron"
+CONF_CONFIG_MULTI = "multi"
 CONF_CONFIG_PREDEFINED = "predefined"
 CONF_CONFIG_TYPE = "config_type"
 CONF_CREATE_CALCULATION_SENSOR = "create_calculation_sensor"
@@ -67,6 +123,7 @@ CONF_TARIFF_ENTITY = "tariff_entity"
 CONFIG_TYPES = [
     CONF_CONFIG_CRON,
     CONF_CONFIG_PREDEFINED,
+    CONF_CONFIG_MULTI,
 ]
 
 CONF_METER_TYPES = [
@@ -89,8 +146,10 @@ ATTR_CALC_LAST_VALUE = "last_period_calculated_value"
 ATTR_CRON_PATTERN = "cron pattern"
 ATTR_LAST_PERIOD = "last_period"
 ATTR_LAST_VALID_STATE = "last_valid_state"
+ATTR_LINKED_METER = "linked_utility_meter"
 ATTR_NEXT_RESET = "next_reset"
 ATTR_PERIOD = "meter_period"
+ATTR_PREDEFINED_CYCLE = "Predefined Cycle"
 ATTR_SOURCE_ID = "source"
 ATTR_STATUS = "status"
 ATTR_TARIFF = "tariff"
@@ -121,14 +180,16 @@ DEVICE_CLASSES_METER = [
 
 PERIOD2CRON = {
     EVERY_FIVE_MINUTES: "{minute}/5 * * * *",
+    EVERY_TEN_MINUTES: "{minute}/10 * * * *",
     QUARTER_HOURLY: "{minute}/15 * * * *",
+    EVERY_TWENTY_MINUTES: "{minute}/20 * * * *",
     HALF_HOURLY: "{minute}/30 * * * *",
     HOURLY: "{minute} * * * *",
     DAILY: "{minute} {hour} * * *",
     WEEKLY: "{minute} {hour} * * {day}",
-    MONTHLY: "{minute} {hour} {day} * *",
-    BIMONTHLY: "{minute} {hour} {day} */2 *",
-    QUARTERLY: "{minute} {hour} {day} */3 *",
-    HALF_YEARLY: "{minute} {hour} {day} */6 *",
-    YEARLY: "{minute} {hour} {day} 1/12 *",
+    MONTHLY: "{minute} {hour} 1 * *",
+    BIMONTHLY: "{minute} {hour} 1 */2 *",
+    QUARTERLY: "{minute} {hour} 1 */3 *",
+    HALF_YEARLY: "{minute} {hour} 1 */6 *",
+    YEARLY: "{minute} {hour} 1 1 *",
 }

--- a/custom_components/utility_meter_next_gen/manifest.json
+++ b/custom_components/utility_meter_next_gen/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/cabberley/utility_meter_evolved/issues",
   "requirements": ["cronsim==2.6"],
   "ssdp": [],
-  "version": "2025.7.6",
+  "version": "2025.7.7",
   "zeroconf": []
 }

--- a/custom_components/utility_meter_next_gen/schemas.py
+++ b/custom_components/utility_meter_next_gen/schemas.py
@@ -8,6 +8,8 @@ from homeassistant.const import CONF_NAME
 from homeassistant.helpers import selector
 
 from .const import (
+    CONF_CONFIG_CALIBRATE_APPLY,
+    CONF_CONFIG_CALIBRATE_CALC_APPLY,
     CONF_CONFIG_CALIBRATE_CALC_VALUE,
     CONF_CONFIG_CALIBRATE_VALUE,
     CONF_CONFIG_CRON,
@@ -30,6 +32,7 @@ from .const import (
     CONFIG_TYPES,
     DEVICE_CLASSES_METER,
     METER_TYPES,
+    MULTI_METER_TYPES,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -60,7 +63,8 @@ BASE_PREDEFINED_CONFIG_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_METER_TYPE): selector.SelectSelector(
             selector.SelectSelectorConfig(
-                options=METER_TYPES, translation_key=CONF_METER_TYPE
+                options=METER_TYPES,
+                translation_key=CONF_METER_TYPE
             ),
         ),
         vol.Optional(CONF_METER_OFFSET,
@@ -78,11 +82,54 @@ BASE_CRON_CONFIG_SCHEMA = vol.Schema(
     }
 )
 
+BASE_MULTI_CONFIG_SCHEMA_STEP_1 = vol.Schema(
+    {
+        vol.Required(CONF_METER_TYPE,default=[]): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=MULTI_METER_TYPES,
+                translation_key=CONF_METER_TYPE,
+                mode=selector.SelectSelectorMode.DROPDOWN,
+                custom_value =False,
+                multiple=True
+            ),
+        ),
+    }
+)
+
+BASE_COMMON_CONFIG_SCHEMA = {
+        vol.Optional(
+            CONF_CONFIG_CALIBRATE_VALUE,
+            default=0
+            ): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                mode=selector.NumberSelectorMode.BOX,
+                step="any",
+                    ),
+        ),
+        vol.Required(CONF_TARIFFS, default=[]): selector.SelectSelector(
+            selector.SelectSelectorConfig(options=[], custom_value=True, multiple=True),
+        ),
+        vol.Required(
+            CONF_METER_NET_CONSUMPTION, default=False
+        ): selector.BooleanSelector(),
+        vol.Required(
+            CONF_METER_DELTA_VALUES, default=False
+        ): selector.BooleanSelector(),
+        vol.Required(
+            CONF_METER_PERIODICALLY_RESETTING,
+            default=True,
+        ): selector.BooleanSelector(),
+        vol.Optional(
+            CONF_SENSOR_ALWAYS_AVAILABLE,
+            default=True,
+        ): selector.BooleanSelector(),
+}
 def create_calc_extras_schema(data):
     """Create the calibration schema for predefined and cron cycles."""
     calibrate_default = data.get(CONF_CONFIG_CALIBRATE_CALC_VALUE,0)
     multiplier_default = data.get(CONF_SOURCE_CALC_MULTIPLIER, 1)
-    create_calc_sensor_default = data.get(CONF_CREATE_CALCULATION_SENSOR, CONF_CREATE_CALCULATION_SENSOR_DEFAULT)
+    create_calc_sensor_default = data.get(CONF_CREATE_CALCULATION_SENSOR,
+            CONF_CREATE_CALCULATION_SENSOR_DEFAULT)
     if data[CONF_SOURCE_CALC_SENSOR] is not None:
         return {
             vol.Required(
@@ -110,8 +157,10 @@ def create_calc_extras_schema(data):
             }
     return {}
 
-
-BASE_COMMON_CONFIG_SCHEMA = {
+def create_common_multi_config_schema_step_2a(data):
+    """Create the common configuration schema for multi configurations."""
+    return vol.Schema(
+        {
         vol.Optional(
             CONF_CONFIG_CALIBRATE_VALUE,
             default=0
@@ -121,6 +170,68 @@ BASE_COMMON_CONFIG_SCHEMA = {
                 step="any",
                     ),
         ),
+        vol.Optional(
+                CONF_CONFIG_CALIBRATE_APPLY):
+                    selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                    options=data.get(CONF_METER_TYPE, []),
+                    translation_key=CONF_METER_TYPE,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                    custom_value =False,
+                    multiple=False
+                ),
+            ),
+        }
+    )
+
+def create_common_multi_config_schema_step_2b(data):
+    """Create the calibration schema for multi cycles."""
+    calibrate_default = data.get(CONF_CONFIG_CALIBRATE_CALC_VALUE,0)
+    multiplier_default = data.get(CONF_SOURCE_CALC_MULTIPLIER, 1)
+    selected_meter_types = data.get(CONF_METER_TYPE, [])
+    create_calc_sensor_default = data.get(CONF_CREATE_CALCULATION_SENSOR,
+        CONF_CREATE_CALCULATION_SENSOR_DEFAULT)
+    if data[CONF_SOURCE_CALC_SENSOR] is not None:
+        return {
+            vol.Required(
+                CONF_CREATE_CALCULATION_SENSOR,
+                default=create_calc_sensor_default):
+                    selector.BooleanSelector(
+                        selector.BooleanSelectorConfig()
+                ),
+            vol.Required(
+                CONF_SOURCE_CALC_MULTIPLIER, default=multiplier_default
+                ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    mode=selector.NumberSelectorMode.BOX,
+                    step="any",
+                    ),
+                ),
+            vol.Required(
+                CONF_CONFIG_CALIBRATE_CALC_VALUE,
+                default=calibrate_default): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    mode=selector.NumberSelectorMode.BOX,
+                    step="any",
+                        ),
+                ),
+            vol.Optional(
+                CONF_CONFIG_CALIBRATE_CALC_APPLY):
+                    selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                    options=selected_meter_types,
+                    translation_key=CONF_METER_TYPE,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                    custom_value =False,
+                    multiple=False
+                    ),
+                ),
+            }
+    return {}
+
+def create_common_multi_config_schema_step_2c():
+    """Create the common configuration schema for multi configurations."""
+    return {
         vol.Required(CONF_TARIFFS, default=[]): selector.SelectSelector(
             selector.SelectSelectorConfig(options=[], custom_value=True, multiple=True),
         ),
@@ -162,6 +273,25 @@ def create_cron_config_schema(data):
         }
     )
 
+def create_multi_config_schema_step_1(data):
+    """Create the configuration schema for predefined cycles."""
+
+    return vol.Schema(
+        {
+            **BASE_MULTI_CONFIG_SCHEMA_STEP_1.schema,
+        }
+    )
+
+def create_multi_config_schema_step_2(data):
+    """Create the configuration schema for predefined cycles."""
+
+    return vol.Schema(
+        {
+            **(create_common_multi_config_schema_step_2a(data)).schema,
+            **create_common_multi_config_schema_step_2b(data),
+            **create_common_multi_config_schema_step_2c()
+        }
+    )
 
 def create_base_predefined_option_schema(data):
     """Create the base options schema for predefined cycles."""
@@ -213,8 +343,6 @@ def create_common_option_schema(data):
                     ),
         ),
     }
-    #if not hasattr(data, CONF_TARIFFS):
-    #    _LOGGER.debug("Config has no Current Tariffs")
     if data[CONF_TARIFFS] != [] and data[CONF_TARIFFS] is not None:
         _LOGGER.debug("Schema Current Tariffs: %s", data[CONF_TARIFFS] )
         option_schema[
@@ -367,7 +495,187 @@ def create_cron_option_schema(data):
     return vol.Schema(
         {**cron_begin.schema,
             **create_base_cron_option_schema(data),
-            #**(create_calc_extras_schema(data) or {}),
             **create_common_option_schema(data)
+        }
+    )
+
+def create_multi_option_schema_step_1(data):
+    """Create the options step 1 schema for multi configurations."""
+    if data[CONF_SOURCE_CALC_SENSOR] is None:
+        multi_option_step_1 = vol.Schema(
+            {
+                vol.Required(CONF_SOURCE_SENSOR,
+                    default=data[CONF_SOURCE_SENSOR]): selector.EntitySelector(
+                    selector.EntitySelectorConfig(
+                        domain=SENSOR_DOMAIN, filter={"device_class": DEVICE_CLASSES_METER}),
+                ),
+                vol.Optional(CONF_SOURCE_CALC_SENSOR ): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain=SENSOR_DOMAIN),
+                ),
+                vol.Required(
+                    CONF_CREATE_CALCULATION_SENSOR,
+                    default=data[CONF_CREATE_CALCULATION_SENSOR]):
+                        selector.BooleanSelector(
+                            selector.BooleanSelectorConfig()
+                ),
+                vol.Required(
+                    CONF_SOURCE_CALC_MULTIPLIER, default=1
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        mode=selector.NumberSelectorMode.BOX,
+                        step="any",
+                        ),
+                ),
+            }
+        )
+    else:
+        multi_option_step_1 = vol.Schema(
+            {
+                vol.Required(CONF_SOURCE_SENSOR,
+                    default=data[CONF_SOURCE_SENSOR]): selector.EntitySelector(
+                    selector.EntitySelectorConfig(
+                        domain=SENSOR_DOMAIN, filter={"device_class": DEVICE_CLASSES_METER}),
+                ),
+                vol.Optional(CONF_SOURCE_CALC_SENSOR,
+                    default=data[CONF_SOURCE_CALC_SENSOR] ): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain=SENSOR_DOMAIN),
+                ),
+                vol.Required(
+                    CONF_CREATE_CALCULATION_SENSOR,
+                    default=data[CONF_CREATE_CALCULATION_SENSOR]):
+                        selector.BooleanSelector(
+                            selector.BooleanSelectorConfig()
+                ),
+                vol.Required(
+                    CONF_REMOVE_CALC_SENSOR,
+                    default=False,
+                ): selector.BooleanSelector(),
+                vol.Required(
+                    CONF_SOURCE_CALC_MULTIPLIER, default=data[CONF_SOURCE_CALC_MULTIPLIER]
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        mode=selector.NumberSelectorMode.BOX,
+                        step="any",
+                        ),
+                ),
+
+            }
+        )
+    meter_types ={
+        vol.Required(CONF_METER_TYPE,default=data[CONF_METER_TYPE]): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=METER_TYPES,
+                translation_key=CONF_METER_TYPE,
+                mode=selector.SelectSelectorMode.DROPDOWN,
+                custom_value =False,
+                multiple=True
+            ),
+        ),
+    }
+    if data[CONF_TARIFFS] != [] and data[CONF_TARIFFS] is not None:
+        _LOGGER.debug("Schema Current Tariffs: %s", data[CONF_TARIFFS] )
+        multi_option_step_tariffs = {
+            vol.Optional(CONF_TARIFFS, default=data[CONF_TARIFFS]):
+            selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=[], custom_value=True, multiple=True
+            ),
+            )
+        }
+    else:
+        _LOGGER.debug("Schema Current Tariffs: %s", data[CONF_TARIFFS] )
+        multi_option_step_tariffs = {}
+    #
+
+    return vol.Schema(
+        {**multi_option_step_1.schema,
+            **meter_types,
+            **multi_option_step_tariffs,
+        }
+    )
+
+def create_multi_option_schema_step_2(data):
+    """Create the options step 2 schema for multi configurations."""
+    multi_option_step_2 = vol.Schema(
+        {
+        vol.Optional(
+            CONF_CONFIG_CALIBRATE_VALUE,
+            default=data[CONF_CONFIG_CALIBRATE_VALUE]): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                mode=selector.NumberSelectorMode.BOX,
+                step="any",
+                    ),
+        ),
+        vol.Required(
+                CONF_CONFIG_CALIBRATE_APPLY,
+                default=data[CONF_CONFIG_CALIBRATE_APPLY]):
+                    selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                    options=data.get(CONF_METER_TYPE, []),
+                    translation_key=CONF_METER_TYPE,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                    custom_value =False,
+                    multiple=False
+                ),
+            ),
+        }
+    )
+    if data[CONF_SOURCE_CALC_SENSOR] is not None:
+        multi_option_calc = {
+            vol.Required(
+                CONF_SOURCE_CALC_MULTIPLIER, data[CONF_SOURCE_CALC_MULTIPLIER]
+                ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    mode=selector.NumberSelectorMode.BOX,
+                    step="any",
+                    ),
+                ),
+            vol.Optional(
+                CONF_CONFIG_CALIBRATE_CALC_VALUE,
+                default=data[CONF_CONFIG_CALIBRATE_CALC_VALUE]): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    mode=selector.NumberSelectorMode.BOX,
+                    step="any",
+                    ),
+                ),
+            vol.Required(
+                CONF_CONFIG_CALIBRATE_CALC_APPLY, default=data[CONF_CONFIG_CALIBRATE_CALC_APPLY]):
+                    selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                    options=data.get(CONF_METER_TYPE, []),
+                    translation_key=CONF_METER_TYPE,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                    custom_value =False,
+                    multiple=False
+                    ),
+                ),
+            }
+    else:
+        multi_option_calc = {}
+
+    multi_option_common = {
+        vol.Required(
+            CONF_METER_NET_CONSUMPTION,
+            default=data[CONF_METER_NET_CONSUMPTION],
+        ): selector.BooleanSelector(),
+        vol.Required(
+            CONF_METER_DELTA_VALUES, default=data[CONF_METER_DELTA_VALUES]
+        ): selector.BooleanSelector(),
+        vol.Required(
+            CONF_METER_PERIODICALLY_RESETTING,
+            default=data[
+                CONF_METER_PERIODICALLY_RESETTING
+            ],  # Assuming this is the correct key
+        ): selector.BooleanSelector(),
+        vol.Optional(
+            CONF_SENSOR_ALWAYS_AVAILABLE,
+            default=data[CONF_SENSOR_ALWAYS_AVAILABLE],
+        ): selector.BooleanSelector(),
+    }
+    return vol.Schema(
+        {**create_multi_option_schema_step_1(data).schema,
+         **multi_option_step_2.schema,
+            **multi_option_calc,
+            **multi_option_common,
         }
     )

--- a/custom_components/utility_meter_next_gen/schemas.py
+++ b/custom_components/utility_meter_next_gen/schemas.py
@@ -585,7 +585,6 @@ def create_multi_option_schema_step_1(data):
     else:
         _LOGGER.debug("Schema Current Tariffs: %s", data[CONF_TARIFFS] )
         multi_option_step_tariffs = {}
-    #
 
     return vol.Schema(
         {**multi_option_step_1.schema,

--- a/custom_components/utility_meter_next_gen/sensor.py
+++ b/custom_components/utility_meter_next_gen/sensor.py
@@ -301,7 +301,7 @@ async def async_setup_entry(
                             calc_sensor
                         )
 
-    else:
+    else: # noqa: PLR5501
         if not tariffs:
             # Add single sensor, not gated by a tariff selector
             meter_sensor = UtilityMeterSensor(

--- a/custom_components/utility_meter_next_gen/strings.json
+++ b/custom_components/utility_meter_next_gen/strings.json
@@ -14,7 +14,7 @@
                     "source_calc_sensor": "Input Calculation Sensor (Optional if you wish to create a price meter)"
                 },
                 "data_description": {
-                    "config_type": "Choose a predefined reset cycle or create a custom CRON pattern.",
+                    "config_type": "Choose the type of Utility Meter to create, predefined reset cycle, custom CRON pattern or a set of predefiend Utility Meters (generate various reset cycles from the one config).",
                     "source_calc_sensor": "If you want to use a sensor to Calculate a price attribute for the Meter, please select it here. If not selected, the meter will just report the source value."
                 },
                 "description": "Create a sensor which tracks consumption of various utilities (e.g., energy, gas, water, heating) over a configured period of time. The utility meter sensor optionally supports splitting the consumption by tariffs, in that case one sensor for each tariff is created as well as a select entity to choose the current tariff and optionally calculating a $$ cost by combining with a price sensor.",
@@ -77,6 +77,47 @@
                     "source_calc_multiplier": "If you need to adjust the calculation to match the raw source sensor, you can set the multiplier here. For example if your Input Calculator Sensor is $/kWh and your Consumption Sensor is in MW, you would set this to 1000 to get the correct price.",
                     "tariffs": "A list of supported tariffs, leave empty if only a single tariff is needed. If you want to track the total consumption, add a 'Total' tariff."
                 }
+            },
+            "multi_step_1": {
+                "data": {
+                    "cycle": "Predefined Reset Cycle"
+                },
+                "description": "Select Predefined reset cycles for the Utility Meter.",
+                "data_description": {
+                    "cycle": "Select one or more predefined reset cycles for the meter."
+                }
+            },
+            "multi_step_2": {
+                "data": {
+                    "always_available": "Sensor always available",
+                    "calibrate_apply": "Apply Calibration to which Predefined Cycle? (Optional)",
+                    "calibrate_calc_apply": "Apply Calculation Calibration to which Predefined Cycle? (Optional)",
+                    "calibrate_calc_value": "Calibration Value for Calculation (Optional)",
+                    "calibrate_value": "Calibration Value for Meter (Optional)",
+                    "create_calculation_sensor": "Create a separate Calculation Sensor (Optional)",
+                    "delta_values": "Delta Values",
+                    "net_consumption": "Net Consumption",
+                    "periodically_resetting": "Periodically resetting",
+                    "source_calc_multiplier": "Adjustment factor for the calculation sensor (Optional)",
+                    "tariffs": "Tariffs - add a 'total' tariff to track total consumption"
+                },
+                "description": "Configure the Utility Meter options.",
+                "data_description": {
+                    "always_available": "If activated, the sensor will always show the last known value, even if the source entity is unavailable or unknown.",
+                    "calibrate_apply": "Apply Calibration to which Predefined Cycle? (If your Calibration is not needed and is set to 0, just leave this to the defaul displayed Cycle)",
+                    "calibrate_calc_apply": "Apply Calculation Calibration to which Predefined Cycle? (If your Calibration is not needed and is set to 0, just leave this to the defaul displayed Cycle)",
+                    "calibrate_calc_value": "When the reset cycle is reached, the calculation sensor will be set to this value. This is useful if you want to start the meter Calc to a specific value.",
+                    "calibrate_value": "When the reset cycle is reached, the consumption sensor will be set to this value. This is useful if you want to start the meter on a specific value.",
+                    "create_calculation_sensor": "In addition to the Consumption Sensor, a Calculation Sensor will be created which can be used to calculate a price attribute for the Meter. If you do not need this, you can disable it here.",
+                    "delta_values": "Enable if the source values are delta values since the last reading instead of absolute values.",
+                    "net_consumption": "Enable if the source is a net meter, meaning it can both increase and decrease.",
+                    "offset": "Offset the day/hour/minute of the meter reset (seconds are ignored atm). This is useful if you want to start the meter on a specific day of the month.",
+                    "periodically_resetting": "Enable if the source may periodically reset to 0, for example at boot of the measuring device. If disabled, new readings are directly recorded after data inavailability.",
+                    "source_calc_multiplier": "If you need to adjust the calculation to match the raw source sensor, you can set the multiplier here. For esxample if your Input Calculator Sensor is $/kWh and your Consumption Sensor is in MW, you would set this to 1000 to get the correct price.",
+                    "tariffs": "A list of supported tariffs, leave empty if only a single tariff is needed. If you want to track the total consumption, add a 'total' tariff."
+
+                },
+                "title": "Configure Options"
             }
         }
     },
@@ -85,8 +126,10 @@
             "init": {
                 "data": {
                     "always_available": "Sensor always available",
+                    "calibrate_apply": "Apply Calibration to which Predefined Cycle? (Optional)",
+                    "calibrate_calc_apply": "Apply Calculation Calibration to which Predefined Cycle? (Optional)",
                     "calibrate_calc_value": "Calibration Value for Calculation (Optional)",
-                    "calibrate_value": "Calibration Value for Consumption (Optional)",
+                    "calibrate_value": "Calibration Value for Meter (Optional)",
                     "create_calculation_sensor": "Create a separate Calculation Sensor (Optional)",
                     "cron": "Custom CRON Pattern",
                     "cycle": "Predefined Reset Cycle",
@@ -102,6 +145,8 @@
                 },
                 "data_description": {
                     "always_available": "If activated, the sensor will always show the last known value, even if the source entity is unavailable or unknown.",
+                    "calibrate_apply": "Apply Calibration to which Predefined Cycle? (If your Calibration is not needed and is set to 0, just leave this to the defaul displayed Cycle)",
+                    "calibrate_calc_apply": "Apply Calculation Calibration to which Predefined Cycle? (If your Calibration is not needed and is set to 0, just leave this to the defaul displayed Cycle)",
                     "calibrate_calc_value": "When the reset cycle is reached, the calculation sensor will be set to this value. This is useful if you want to start the meter Calc to a specific value.",
                     "calibrate_value": "When the reset cycle is reached, the consumption sensor will be set to this value. This is useful if you want to start the meter on a specific value.",
                     "create_calculation_sensor": "In addition to the Consumption Sensor, a Calculation Sensor will be created which can be used to calculate a price attribute for the Meter. If you do not need this, you can disable it here.",
@@ -115,6 +160,23 @@
                     "source_calc_sensor": "If you want to use a sensor to Calculate a price attribute for the Meter, please select it here. If not selected, the meter will just report the source value.",
                     "tariffs": "A list of supported tariffs, leave empty if only a single tariff is needed. If you want to track the total consumption, add a 'Total' tariff."
                 }
+            },
+            "init_2": {
+                "data": {
+                    "config_calibrate_apply": "Apply Calibration",
+                    "config_calibrate_value": "Calibration Value",
+                    "config_cron": "Custom CRON Pattern",
+                    "config_type": "Configuration Type",
+                    "source_calc_multiplier": "Adjustment factor for the calculation sensor (Optional)"
+                },
+                "data_description": {
+                    "config_calibrate_apply": "Select the sensor to which the calibration value should be applied.",
+                    "config_calibrate_value": "Set the value to which the meter should be calibrated.",
+                    "config_cron": "Enter a custom CRON pattern for the reset cycle.",
+                    "config_type": "Choose between predefined cycles or custom CRON patterns.",
+                    "source_calc_multiplier": "If you need to adjust the calculation to match the raw source sensor, you can set the multiplier here."
+                },
+                "title": "Configure Options"
             }
         }
     },
@@ -124,6 +186,8 @@
                 "bimonthly": "Every two months",
                 "daily": "Daily",
                 "every-five-minutes": "Every 5 minutes",
+                "every-ten-minutes": "Every 10 minutes",
+                "every-twenty-minutes": "Every 20 minutes",
                 "half-hourly": "Every 30 minutes",
                 "half-yearly": "Half Yearly",
                 "hourly": "Hourly",
@@ -137,8 +201,9 @@
         },
         "config_type": {
             "options": {
-            "cron": "Create Custom CRON Pattern",
-            "predefined": "Use Predefined reset cycle"
+            "cron": "Create using a custom CRON pattern",
+            "predefined": "Create using a Predefined reset cycle",
+            "multi": "Create Multiple Predefined reset cycle Meters"
             }
         }
     },

--- a/custom_components/utility_meter_next_gen/strings.json
+++ b/custom_components/utility_meter_next_gen/strings.json
@@ -111,7 +111,6 @@
                     "create_calculation_sensor": "In addition to the Consumption Sensor, a Calculation Sensor will be created which can be used to calculate a price attribute for the Meter. If you do not need this, you can disable it here.",
                     "delta_values": "Enable if the source values are delta values since the last reading instead of absolute values.",
                     "net_consumption": "Enable if the source is a net meter, meaning it can both increase and decrease.",
-                    "offset": "Offset the day/hour/minute of the meter reset (seconds are ignored atm). This is useful if you want to start the meter on a specific day of the month.",
                     "periodically_resetting": "Enable if the source may periodically reset to 0, for example at boot of the measuring device. If disabled, new readings are directly recorded after data inavailability.",
                     "source_calc_multiplier": "If you need to adjust the calculation to match the raw source sensor, you can set the multiplier here. For esxample if your Input Calculator Sensor is $/kWh and your Consumption Sensor is in MW, you would set this to 1000 to get the correct price.",
                     "tariffs": "A list of supported tariffs, leave empty if only a single tariff is needed. If you want to track the total consumption, add a 'total' tariff."

--- a/custom_components/utility_meter_next_gen/translations/en.json
+++ b/custom_components/utility_meter_next_gen/translations/en.json
@@ -14,7 +14,7 @@
                     "source_calc_sensor": "Input Calculation Sensor (Optional if you wish to create a price meter)"
                 },
                 "data_description": {
-                    "config_type": "Choose a predefined reset cycle or create a custom CRON pattern.",
+                    "config_type": "Choose the type of Utility Meter to create, predefined reset cycle, custom CRON pattern or a set of predefiend Utility Meters (generate various reset cycles from the one config).",
                     "source_calc_sensor": "If you want to use a sensor to Calculate a price attribute for the Meter, please select it here. If not selected, the meter will just report the source value."
                 },
                 "description": "Create a sensor which tracks consumption of various utilities (e.g., energy, gas, water, heating) over a configured period of time. The utility meter sensor optionally supports splitting the consumption by tariffs, in that case one sensor for each tariff is created as well as a select entity to choose the current tariff and optionally calculating a $$ cost by combining with a price sensor.",
@@ -77,6 +77,47 @@
                     "source_calc_multiplier": "If you need to adjust the calculation to match the raw source sensor, you can set the multiplier here. For example if your Input Calculator Sensor is $/kWh and your Consumption Sensor is in MW, you would set this to 1000 to get the correct price.",
                     "tariffs": "A list of supported tariffs, leave empty if only a single tariff is needed. If you want to track the total consumption, add a 'Total' tariff."
                 }
+            },
+            "multi_step_1": {
+                "data": {
+                    "cycle": "Predefined Reset Cycle"
+                },
+                "description": "Select Predefined reset cycles for the Utility Meter.",
+                "data_description": {
+                    "cycle": "Select one or more predefined reset cycles for the meter."
+                }
+            },
+            "multi_step_2": {
+                "data": {
+                    "always_available": "Sensor always available",
+                    "calibrate_apply": "Apply Calibration to which Predefined Cycle? (Optional)",
+                    "calibrate_calc_apply": "Apply Calculation Calibration to which Predefined Cycle? (Optional)",
+                    "calibrate_calc_value": "Calibration Value for Calculation (Optional)",
+                    "calibrate_value": "Calibration Value for Meter (Optional)",
+                    "create_calculation_sensor": "Create a separate Calculation Sensor (Optional)",
+                    "delta_values": "Delta Values",
+                    "net_consumption": "Net Consumption",
+                    "periodically_resetting": "Periodically resetting",
+                    "source_calc_multiplier": "Adjustment factor for the calculation sensor (Optional)",
+                    "tariffs": "Tariffs - add a 'total' tariff to track total consumption"
+                },
+                "description": "Configure the Utility Meter options.",
+                "data_description": {
+                    "always_available": "If activated, the sensor will always show the last known value, even if the source entity is unavailable or unknown.",
+                    "calibrate_apply": "Apply Calibration to which Predefined Cycle? (If your Calibration is not needed and is set to 0, just leave this to the defaul displayed Cycle)",
+                    "calibrate_calc_apply": "Apply Calculation Calibration to which Predefined Cycle? (If your Calibration is not needed and is set to 0, just leave this to the defaul displayed Cycle)",
+                    "calibrate_calc_value": "When the reset cycle is reached, the calculation sensor will be set to this value. This is useful if you want to start the meter Calc to a specific value.",
+                    "calibrate_value": "When the reset cycle is reached, the consumption sensor will be set to this value. This is useful if you want to start the meter on a specific value.",
+                    "create_calculation_sensor": "In addition to the Consumption Sensor, a Calculation Sensor will be created which can be used to calculate a price attribute for the Meter. If you do not need this, you can disable it here.",
+                    "delta_values": "Enable if the source values are delta values since the last reading instead of absolute values.",
+                    "net_consumption": "Enable if the source is a net meter, meaning it can both increase and decrease.",
+                    "offset": "Offset the day/hour/minute of the meter reset (seconds are ignored atm). This is useful if you want to start the meter on a specific day of the month.",
+                    "periodically_resetting": "Enable if the source may periodically reset to 0, for example at boot of the measuring device. If disabled, new readings are directly recorded after data inavailability.",
+                    "source_calc_multiplier": "If you need to adjust the calculation to match the raw source sensor, you can set the multiplier here. For esxample if your Input Calculator Sensor is $/kWh and your Consumption Sensor is in MW, you would set this to 1000 to get the correct price.",
+                    "tariffs": "A list of supported tariffs, leave empty if only a single tariff is needed. If you want to track the total consumption, add a 'total' tariff."
+
+                },
+                "title": "Configure Options"
             }
         }
     },
@@ -85,8 +126,10 @@
             "init": {
                 "data": {
                     "always_available": "Sensor always available",
+                    "calibrate_apply": "Apply Calibration to which Predefined Cycle? (Optional)",
+                    "calibrate_calc_apply": "Apply Calculation Calibration to which Predefined Cycle? (Optional)",
                     "calibrate_calc_value": "Calibration Value for Calculation (Optional)",
-                    "calibrate_value": "Calibration Value for Consumption (Optional)",
+                    "calibrate_value": "Calibration Value for Meter (Optional)",
                     "create_calculation_sensor": "Create a separate Calculation Sensor (Optional)",
                     "cron": "Custom CRON Pattern",
                     "cycle": "Predefined Reset Cycle",
@@ -94,7 +137,7 @@
                     "net_consumption": "Net Consumption",
                     "offset": "Offset (optional, e.g., to set a starting value for the meter)",
                     "periodically_resetting": "Periodically resetting",
-                    "remove_calc_sensor": "Remove Calculation Sensor",
+                    "remove_calc_sensor": "Remove Input Calculation Sensor",
                     "source": "Input sensor to track consumption (Required)",
                     "source_calc_multiplier": "Adjustment factor for the calculation sensor (Optional)",
                     "source_calc_sensor": "Input calculation Sensor (Optional if you wish to create a price meter)",
@@ -102,6 +145,8 @@
                 },
                 "data_description": {
                     "always_available": "If activated, the sensor will always show the last known value, even if the source entity is unavailable or unknown.",
+                    "calibrate_apply": "Apply Calibration to which Predefined Cycle? (If your Calibration is not needed and is set to 0, just leave this to the defaul displayed Cycle)",
+                    "calibrate_calc_apply": "Apply Calculation Calibration to which Predefined Cycle? (If your Calibration is not needed and is set to 0, just leave this to the defaul displayed Cycle)",
                     "calibrate_calc_value": "When the reset cycle is reached, the calculation sensor will be set to this value. This is useful if you want to start the meter Calc to a specific value.",
                     "calibrate_value": "When the reset cycle is reached, the consumption sensor will be set to this value. This is useful if you want to start the meter on a specific value.",
                     "create_calculation_sensor": "In addition to the Consumption Sensor, a Calculation Sensor will be created which can be used to calculate a price attribute for the Meter. If you do not need this, you can disable it here.",
@@ -115,6 +160,23 @@
                     "source_calc_sensor": "If you want to use a sensor to Calculate a price attribute for the Meter, please select it here. If not selected, the meter will just report the source value.",
                     "tariffs": "A list of supported tariffs, leave empty if only a single tariff is needed. If you want to track the total consumption, add a 'Total' tariff."
                 }
+            },
+            "init_2": {
+                "data": {
+                    "config_calibrate_apply": "Apply Calibration",
+                    "config_calibrate_value": "Calibration Value",
+                    "config_cron": "Custom CRON Pattern",
+                    "config_type": "Configuration Type",
+                    "source_calc_multiplier": "Adjustment factor for the calculation sensor (Optional)"
+                },
+                "data_description": {
+                    "config_calibrate_apply": "Select the sensor to which the calibration value should be applied.",
+                    "config_calibrate_value": "Set the value to which the meter should be calibrated.",
+                    "config_cron": "Enter a custom CRON pattern for the reset cycle.",
+                    "config_type": "Choose between predefined cycles or custom CRON patterns.",
+                    "source_calc_multiplier": "If you need to adjust the calculation to match the raw source sensor, you can set the multiplier here."
+                },
+                "title": "Configure Options"
             }
         }
     },
@@ -124,6 +186,8 @@
                 "bimonthly": "Every two months",
                 "daily": "Daily",
                 "every-five-minutes": "Every 5 minutes",
+                "every-ten-minutes": "Every 10 minutes",
+                "every-twenty-minutes": "Every 20 minutes",
                 "half-hourly": "Every 30 minutes",
                 "half-yearly": "Half Yearly",
                 "hourly": "Hourly",
@@ -137,8 +201,9 @@
         },
         "config_type": {
             "options": {
-            "cron": "Create Custom CRON Pattern",
-            "predefined": "Use Predefined reset cycle"
+            "cron": "Create using a custom CRON pattern",
+            "predefined": "Create using a Predefined reset cycle",
+            "multi": "Create Multiple Predefined reset cycle Meters"
             }
         }
     },

--- a/custom_components/utility_meter_next_gen/translations/en.json
+++ b/custom_components/utility_meter_next_gen/translations/en.json
@@ -111,7 +111,6 @@
                     "create_calculation_sensor": "In addition to the Consumption Sensor, a Calculation Sensor will be created which can be used to calculate a price attribute for the Meter. If you do not need this, you can disable it here.",
                     "delta_values": "Enable if the source values are delta values since the last reading instead of absolute values.",
                     "net_consumption": "Enable if the source is a net meter, meaning it can both increase and decrease.",
-                    "offset": "Offset the day/hour/minute of the meter reset (seconds are ignored atm). This is useful if you want to start the meter on a specific day of the month.",
                     "periodically_resetting": "Enable if the source may periodically reset to 0, for example at boot of the measuring device. If disabled, new readings are directly recorded after data inavailability.",
                     "source_calc_multiplier": "If you need to adjust the calculation to match the raw source sensor, you can set the multiplier here. For esxample if your Input Calculator Sensor is $/kWh and your Consumption Sensor is in MW, you would set this to 1000 to get the correct price.",
                     "tariffs": "A list of supported tariffs, leave empty if only a single tariff is needed. If you want to track the total consumption, add a 'total' tariff."


### PR DESCRIPTION
modified:   README.md
	modified:   custom_components/utility_meter_next_gen/__init__.py
	modified:   custom_components/utility_meter_next_gen/config_flow.py
	modified:   custom_components/utility_meter_next_gen/const.py
	modified:   custom_components/utility_meter_next_gen/manifest.json
	modified:   custom_components/utility_meter_next_gen/schemas.py
	modified:   custom_components/utility_meter_next_gen/sensor.py
	modified:   custom_components/utility_meter_next_gen/strings.json
	modified:   custom_components/utility_meter_next_gen/translations/en.json

# Proposed Changes

>Code that introduces the new Multiple Predefined Recycle Periods options

## Related Issues

> Adjusted Cron configs for Monthly and Yearly/Sub Yearly to cycle correctly.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

## Summary by Sourcery

Enable creation of multiple predefined recycle-period meters in one integration setup, enhance state attributes and config flow to support per-cycle calibration and a new multi-step configuration path.

New Features:
- Support selecting multiple predefined reset cycles in a single meter configuration to auto-generate corresponding sensors and optional calculation sensors per period
- Add two new interval types (10-minute and 20-minute) plus display-friendly names for all predefined meter types
- Introduce a new “multi” configuration flow with a two-step UI for selecting meter types and applying calibration to specific cycles

Enhancements:
- Include ATTR_LINKED_METER and ATTR_PREDEFINED_CYCLE attributes on sensors for improved state visibility
- Extend sensor setup to handle calibration values per meter type and tariff, and adjust cron patterns for monthly/yearly cycles
- Add clean_string_display helper for formatting meter names

Documentation:
- Revise README to document the multi predefined reset cycle feature and update HACS installation instructions

Chores:
- Bump manifest version to 2025.7.7 and migrate config entry versions to add new calibration options