### PR TITLE
Multi period calculation bug fix

### DIFF
--- a/custom_components/utility_meter_next_gen/manifest.json
+++ b/custom_components/utility_meter_next_gen/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/cabberley/utility_meter_evolved/issues",
   "requirements": ["cronsim==2.6"],
   "ssdp": [],
-  "version": "2025.7.9",
+  "version": "2025.7.10",
   "zeroconf": []
 }

--- a/custom_components/utility_meter_next_gen/sensor.py
+++ b/custom_components/utility_meter_next_gen/sensor.py
@@ -773,19 +773,15 @@ class UtilityMeterSensor(RestoreSensor):
                 and source_calc_state.state not in [STATE_UNAVAILABLE, STATE_UNKNOWN]
             ):
                 try:
-                    if str(self._tariff).lower() in [SINGLE_TARIFF, TOTAL_TARIFF]:
-                        # If the tariff is a single tariff or total, we use the calibration value
-                        calibrate_value = Decimal(self._calibrate_calc_value)
-                    else:
-                        # If the tariff is not a single tariff or total, we use 0 as the calibration value
-                        calibrate_value = Decimal(0)
-                    self._attr_calculated_current_value = round(
+                    self._attr_calculated_current_value += round(
                         (
                             Decimal(source_calc_state.state)
-                            * Decimal(self._attr_native_value)
+                            # Bug fix with Multi Meters we need to use
+                            # the adjustment and add not just recalc
+                            # Decimal(self._attr_native_value)
+                            * Decimal(adjustment)
                             * Decimal(self._attr_multiplier)
-                        )
-                        + calibrate_value,
+                        ),
                         PRECISION,
                     )
                 except (DecimalException, InvalidOperation) as err:


### PR DESCRIPTION
modified:   custom_components/utility_meter_next_gen/manifest.json
	modified:   custom_components/utility_meter_next_gen/sensor.py

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

## Summary by Sourcery

Fix multi-period meter calculation by using incremental adjustments and the correct adjustment factor instead of full recalibration, and bump version to 2025.7.10

Bug Fixes:
- Accumulate calculated current value using the adjustment factor for multi-tariff meters instead of recalculating from native value and calibration logic

Chores:
- Bump component version to 2025.7.10 in manifest