### PR TITLE
Bug Fixes for Calculation sensor value not surviving HA restarts

### DIFF
--- a/custom_components/utility_meter_next_gen/manifest.json
+++ b/custom_components/utility_meter_next_gen/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/cabberley/utility_meter_evolved/issues",
   "requirements": ["cronsim==2.6"],
   "ssdp": [],
-  "version": "2025.7.10",
+  "version": "2025.7.11",
   "zeroconf": []
 }


### PR DESCRIPTION
modified:   custom_components/utility_meter_next_gen/manifest.json
	modified:   custom_components/utility_meter_next_gen/sensor.py

# Proposed Changes

> Calculation Sensor value not surviving restarts

## Summary by Sourcery

Fix calculation sensor values not persisting across Home Assistant restarts by adding persistence fields and restoring them on startup, and bump integration version.

Bug Fixes:
- Persist calculated_current_value and calculated_last_value in the sensor restore data and restore them on integration startup.

Enhancements:
- Initialize and handle calculated values consistently as Decimal instances and clean up redundant availability assignments.

Chores:
- Bump custom_components/utility_meter_next_gen version to 2025.7.11.