### PR TITLE
Tariff Total - miscalculating

### DIFF
--- a/custom_components/utility_meter_next_gen/manifest.json
+++ b/custom_components/utility_meter_next_gen/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/cabberley/utility_meter_evolved/issues",
   "requirements": ["cronsim==2.6"],
   "ssdp": [],
-  "version": "2025.7.11",
+  "version": "2025.7.12",
   "zeroconf": []
 }

--- a/custom_components/utility_meter_next_gen/sensor.py
+++ b/custom_components/utility_meter_next_gen/sensor.py
@@ -171,7 +171,7 @@ async def async_setup_entry(
     calc_sensors = []
     tariffs = config_entry.options[CONF_TARIFFS]
 
-    if meter_type is not None and not isinstance(meter_type, str) and len(meter_type) > 1: # noqa: PLR5501
+    if meter_type is not None and not isinstance(meter_type, str) and len(meter_type) > 1:
         for meter in meter_type:
             if not tariffs:
                 # Add single sensor, not gated by a tariff selector


### PR DESCRIPTION
modified:   custom_components/utility_meter_next_gen/manifest.json
	modified:   custom_components/utility_meter_next_gen/sensor.py

# Proposed Changes

> Hopefully fixed a bug in the way the Total Tariff was being treated.

## Related Issues

> 

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

## Summary by Sourcery

Fix miscalculation of TOTAL_TARIFF by simplifying reset logic and refining tariff tracking conditions

Bug Fixes:
- Always apply calibration values on meter reset to correct total tariff computation
- Refine tariff change detection and source tracking to properly handle TOTAL_TARIFF

Enhancements:
- Add debug logging for tariff sensors initialization, adjustment calculations, and state updates

Build:
- Bump component version to 2025.7.12