### PR TITLE
Handle import of is_number with fallback

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.14"
+          python-version: "3.13.2"
           cache: "pip"
 
       - name: Install requirements

--- a/custom_components/utility_meter_next_gen/sensor.py
+++ b/custom_components/utility_meter_next_gen/sensor.py
@@ -50,6 +50,10 @@ from homeassistant.helpers.event import (
     async_track_state_report_event,
 )
 from homeassistant.helpers.start import async_at_started
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.util import dt as dt_util, slugify
+from homeassistant.util.enum import try_parse_enum
+
 try:
     from homeassistant.helpers.template.extensions.type_cast import (
         TypeCastExtension,
@@ -58,9 +62,6 @@ try:
     is_number = TypeCastExtension.is_number
 except ImportError:
     from homeassistant.helpers.template import is_number
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.util import dt as dt_util, slugify
-from homeassistant.util.enum import try_parse_enum
 
 from .const import (
     ATTR_CALC_CURRENT_VALUE,

--- a/custom_components/utility_meter_next_gen/sensor.py
+++ b/custom_components/utility_meter_next_gen/sensor.py
@@ -50,7 +50,14 @@ from homeassistant.helpers.event import (
     async_track_state_report_event,
 )
 from homeassistant.helpers.start import async_at_started
-from homeassistant.helpers.template import is_number
+try:
+    from homeassistant.helpers.template.extensions.type_cast import (
+        TypeCastExtension,
+    )
+
+    is_number = TypeCastExtension.is_number
+except ImportError:
+    from homeassistant.helpers.template import is_number
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util, slugify
 from homeassistant.util.enum import try_parse_enum


### PR DESCRIPTION
# Proposed Changes

>Patch to accomodate HA moving is_number to different library

## Summary by Sourcery

Bug Fixes:
- Prevent failures when Home Assistant relocates the is_number helper by providing a backward-compatible import path.