### PR TITLE
devices: support Home Assistant 2026.8 ownership model

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,3 +30,27 @@ jobs:
       - name: Lint
         run: python3 -m ruff check .
 
+      - name: Check formatting
+        run: python3 -m ruff format . --check
+
+  test:
+    name: "Tests"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14.6"
+          cache: "pip"
+
+      - name: Install test dependencies
+        run: >-
+          python3 -m pip install
+          pytest-homeassistant-custom-component==0.13.353
+          cronsim==2.7
+
+      - name: Test
+        run: python3 -m pytest

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -119,6 +119,7 @@ ignore = [
   "PLR0912", # Too many branches ({branches} > {max_branches})
   "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
   "PLR0915", # Too many statements ({statements} > {max_statements})
+  "PLR0917", # Too many positional arguments in existing entities and fixtures
   "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
   "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
   "PT011",   # pytest.raises({exception}) is too broad, set the `match` parameter or use a more specific exception
@@ -141,9 +142,6 @@ ignore = [
 
   "TRY003", # Avoid specifying long messages outside the exception class
   "TRY400", # Use `logging.exception` instead of `logging.error`
-  # Ignored due to performance: https://github.com/charliermarsh/ruff/issues/2923
-  "UP038", # Use `X | Y` in `isinstance` call instead of `(X, Y)`
-
   # May conflict with the formatter, https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
   "W191",
   "E111",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,10 @@ Pull requests are the best way to propose changes to the codebase.
 
 1. Fork the repo and create your branch from `main`.
 2. If you've changed something, update the documentation.
-3. Make sure your code lints (using `scripts/lint`).
-4. Test you contribution.
-5. Issue that pull request!
+3. Make sure your code lints with `python -m ruff check .`.
+4. Format the code with `python -m ruff format .`.
+5. Test your contribution with `python -m pytest`.
+6. Issue that pull request!
 
 ## Any contributions you make will be under the MIT Software License
 
@@ -44,7 +45,7 @@ People *love* thorough bug reports. I'm not even kidding.
 
 ## Use a Consistent Coding Style
 
-Use [black](https://github.com/ambv/black) to make sure the code follows the style.
+Use [Ruff](https://docs.astral.sh/ruff/) to format and lint Python code.
 
 ## Test your code modification
 
@@ -55,6 +56,14 @@ if you use Visual Studio Code. With this container you will have a stand alone
 Home Assistant instance running and already configured with the included
 [`configuration.yaml`](./config/configuration.yaml)
 file.
+
+The device-management tests require the Home Assistant custom component pytest
+plugin:
+
+```shell
+python -m pip install pytest-homeassistant-custom-component
+python -m pytest tests/components/utility_meter_evolved/test_device_management.py
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ This custom HACS integration for Home Assistant provides an enhanced set of capa
 
 Based on the current "Utility Meter" component code in the Home-Assistant/Core. Acknowledgements to [DGomes](https://github.com/dgomes) who is the Code Owner of the core utlity Meter who really did all the hard logic work for the Meter Utility.
 
+## Compatibility
+
+Release 2026.8.0 and newer require Home Assistant 2026.8.0 or later. Utility
+Meter Next Gen entities link directly to their source device while the source
+integration remains the device's sole owner, matching Home Assistant's current
+device registry model.
+
 There are lots of enhancements that the Utility Meter Next Gen has added to the original Utility Meter include:
 
 - **Create multiple period sensors, optionally with Tariffs and individual Calculation sensors from a single Source and Calculation Sensor**
@@ -124,4 +131,3 @@ A good example of using the calibration sensor is if you are tracking the Cost o
 
 - if your Consumption is being recorded as MWh and your Calculation Sensor is $/kWh then you want to convert your MWh to kWH to achieve this the multiplier should be set to 1000.
 - if your Consumption is being recorded as Wh and your Calculation Sensor is $/kWh then you want to convert your MWh to kWH to achieve this the multiplier should be set to 0.0001.
-

--- a/custom_components/utility_meter_next_gen/__init__.py
+++ b/custom_components/utility_meter_next_gen/__init__.py
@@ -16,13 +16,11 @@ from homeassistant.helpers import (
     discovery,
     entity_registry as er,
 )
-from homeassistant.helpers.device import (
-    async_entity_id_to_device_id,
-    async_remove_stale_devices_links_keep_entity_device,
-)
+from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.helper_integration import (
-    async_handle_source_entity_changes,  # noqa: PGH003 # type: ignore
+    async_handle_source_entity_changes,
+    async_remove_helper_devices,
 )
 from homeassistant.helpers.typing import ConfigType
 
@@ -57,6 +55,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+
 def validate_cron_pattern(pattern):
     """Check that the pattern is well-formed."""
     try:
@@ -66,6 +65,7 @@ def validate_cron_pattern(pattern):
         _LOGGER.error("Invalid cron pattern %s: %s", pattern, err)
         raise vol.Invalid("Invalid pattern") from err
     return pattern
+
 
 def period_or_cron(config):
     """Check that if cron pattern is used, then meter type and offsite must be removed."""
@@ -81,6 +81,7 @@ def period_or_cron(config):
         )
     return config
 
+
 METER_CONFIG_SCHEMA = vol.Schema(
     vol.All(
         {
@@ -88,8 +89,9 @@ METER_CONFIG_SCHEMA = vol.Schema(
             vol.Optional(CONF_NAME): cv.string,
             vol.Optional(CONF_UNIQUE_ID): cv.string,
             vol.Optional(CONF_METER_TYPE): vol.In(CONF_METER_TYPES),
-            vol.Optional(CONF_METER_OFFSET,
-                default=CONF_METER_OFFSET_DURATION_DEFAULT): cv.ensure_list,
+            vol.Optional(
+                CONF_METER_OFFSET, default=CONF_METER_OFFSET_DURATION_DEFAULT
+            ): cv.ensure_list,
             vol.Optional(CONF_METER_DELTA_VALUES, default=False): cv.boolean,
             vol.Optional(CONF_METER_NET_CONSUMPTION, default=False): cv.boolean,
             vol.Optional(CONF_METER_PERIODICALLY_RESETTING, default=True): cv.boolean,
@@ -190,13 +192,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     return True
 
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Utility Meter from a config entry."""
-
-    async_remove_stale_devices_links_keep_entity_device(
-        hass, entry.entry_id, entry.options[CONF_SOURCE_SENSOR]
-    )
-
     entity_registry = er.async_get(hass)
     hass.data[DATA_UTILITY][entry.entry_id] = {
         "source": entry.options[CONF_SOURCE_SENSOR],
@@ -219,10 +217,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             options={**entry.options, CONF_SOURCE_SENSOR: source_entity_id},
         )
 
-    async def source_entity_removed() -> None:
-        # The source entity has been removed, we need to clean the device links.
-        async_remove_stale_devices_links_keep_entity_device(hass, entry.entry_id, None)
-
     entry.async_on_unload(
         async_handle_source_entity_changes(
             hass,
@@ -232,7 +226,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 hass, entry.options[CONF_SOURCE_SENSOR]
             ),
             source_entity_id_or_uuid=entry.options[CONF_SOURCE_SENSOR],
-            source_entity_removed=source_entity_removed,
         )
     )
 
@@ -243,9 +236,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     else:
         # Create tariff selection + one meter sensor for each tariff
         entity_entry = entity_registry.async_get_or_create(
-            Platform.SELECT, DOMAIN, entry.entry_id, suggested_object_id=entry.title
+            Platform.SELECT, DOMAIN, entry.entry_id, object_id_base=entry.title
         )
-        #entry.options[CONF_TARIFFS].append("total")
         hass.data[DATA_UTILITY][entry.entry_id][CONF_TARIFF_ENTITY] = (
             entity_entry.entity_id
         )
@@ -280,53 +272,61 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
-    """Migrate old entry."""
-    _LOGGER.debug("Migrating from version %s", config_entry.version)
+    """Migrate an entry to the current data and device model."""
+    version = config_entry.version or 2
+    options = dict(config_entry.options)
+    _LOGGER.debug(
+        "Migrating config entry from version %s.%s",
+        version,
+        config_entry.minor_version,
+    )
 
-    if config_entry.version == 1:
-        new = {**config_entry.options,CONF_METER_PERIODICALLY_RESETTING: True}
-        hass.config_entries.async_update_entry(config_entry, options=new, version=2)
+    if version == 1:
+        options[CONF_METER_PERIODICALLY_RESETTING] = True
+        version = 2
+    if version == 2:
+        options[CONF_SOURCE_CALC_MULTIPLIER] = 1
+        version = 3
+    if version == 3:
+        options[CONF_CONFIG_CALIBRATE_CALC_VALUE] = 0
+        options[CONF_CONFIG_CALIBRATE_VALUE] = 0
+        version = 4
+    if version == 4:
+        options[CONF_CONFIG_CALIBRATE_CALC_VALUE] = 0
+        version = 5
+    if version == 5:
+        options[CONF_CREATE_CALCULATION_SENSOR] = CONF_CREATE_CALCULATION_SENSOR_DEFAULT
+        version = 6
+    if version == 6:
+        options[CONF_CONFIG_CALIBRATE_CALC_APPLY] = None
+        version = 7
+    if version == 7:
+        options[CONF_CONFIG_CALIBRATE_APPLY] = None
+        version = 8
 
-    _LOGGER.info("Migration to version %s successful", config_entry.version)
+    if version != 8:
+        _LOGGER.error(
+            "Unsupported config entry version %s.%s",
+            version,
+            config_entry.minor_version,
+        )
+        return False
 
-    if config_entry.version == 2 or config_entry.version is None:
-        new = {**config_entry.options, CONF_SOURCE_CALC_MULTIPLIER: 1}
-        hass.config_entries.async_update_entry(config_entry, options=new, version=3)
+    if config_entry.minor_version < 2:
+        async_remove_helper_devices(
+            hass,
+            helper_config_entry_id=config_entry.entry_id,
+            source_device_id=async_entity_id_to_device_id(
+                hass, options[CONF_SOURCE_SENSOR]
+            ),
+            remove_all_devices=True,
+        )
 
-    _LOGGER.info("Migration to version %s successful", config_entry.version)
-
-    if config_entry.version == 3:
-        new = {**config_entry.options, CONF_CONFIG_CALIBRATE_CALC_VALUE: 0}
-        new = {**config_entry.options, CONF_CONFIG_CALIBRATE_VALUE: 0}
-        hass.config_entries.async_update_entry(config_entry, options=new, version=4)
-
-    _LOGGER.info("Migration to version %s successful", config_entry.version)
-
-    if config_entry.version == 4:
-        new = {**config_entry.options, CONF_CONFIG_CALIBRATE_CALC_VALUE: 0}
-        hass.config_entries.async_update_entry(config_entry, options=new, version=5)
-
-    _LOGGER.info("Migration to version %s successful", config_entry.version)
-
-    if config_entry.version == 5:
-        new = {**config_entry.options,
-               CONF_CREATE_CALCULATION_SENSOR: CONF_CREATE_CALCULATION_SENSOR_DEFAULT}
-        hass.config_entries.async_update_entry(config_entry, options=new, version=6)
-
-    _LOGGER.info("Migration to version %s successful", config_entry.version)
-
-    if config_entry.version == 6:
-        new = {**config_entry.options,
-               CONF_CONFIG_CALIBRATE_CALC_APPLY: None}
-        hass.config_entries.async_update_entry(config_entry, options=new, version=7)
-
-    _LOGGER.info("Migration to version %s successful", config_entry.version)
-
-    if config_entry.version == 7:
-        new = {**config_entry.options,
-               CONF_CONFIG_CALIBRATE_APPLY: None}
-        hass.config_entries.async_update_entry(config_entry, options=new, version=8)
-
-    _LOGGER.info("Migration to version %s successful", config_entry.version)
-
+    hass.config_entries.async_update_entry(
+        config_entry,
+        options=options,
+        version=8,
+        minor_version=2,
+    )
+    _LOGGER.debug("Migration to version 8.2 successful")
     return True

--- a/custom_components/utility_meter_next_gen/config_flow.py
+++ b/custom_components/utility_meter_next_gen/config_flow.py
@@ -47,23 +47,26 @@ from .schemas import (
 
 _LOGGER = logging.getLogger(__name__)
 
+
 async def validate():
     """Validate the configuration."""
     # This function can be extended to include any validation logic needed.
     return True
 
+
 class UtilityMeterEvolvedCustomConfigFlow(ConfigFlow, domain=DOMAIN):
     """Github Custom config flow."""
 
     VERSION = 8
+    MINOR_VERSION = 2
 
     data: Optional[dict[str, Any]]  # noqa: UP045
 
     @staticmethod
-    def _validate_state(state: State | None) -> Decimal | None: # noqa: F821
+    def _validate_state(state: State | None) -> Decimal | None:  # noqa: F821
         """Parse the state as a Decimal if available."""
 
-        #Throws DecimalException if the state is not a number.
+        # Throws DecimalException if the state is not a number.
 
         try:
             return (
@@ -73,6 +76,7 @@ class UtilityMeterEvolvedCustomConfigFlow(ConfigFlow, domain=DOMAIN):
             )
         except DecimalException:
             return None
+
     async def async_step_user(self, user_input: Optional[dict[str, Any]] = None):  # noqa: UP045
         """Initiate a flow when a user starts via the user interface."""
 
@@ -91,7 +95,9 @@ class UtilityMeterEvolvedCustomConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "source_sensor_not_a_number"
             try:
                 if CONF_SOURCE_CALC_SENSOR in user_input:
-                    source_state = self.hass.states.get(user_input[CONF_SOURCE_CALC_SENSOR])
+                    source_state = self.hass.states.get(
+                        user_input[CONF_SOURCE_CALC_SENSOR]
+                    )
                     if source_state is None:
                         errors["base"] = "source_calc_sensor_not_found"
                     elif source_state.state in [STATE_UNAVAILABLE, STATE_UNKNOWN]:
@@ -115,7 +121,7 @@ class UtilityMeterEvolvedCustomConfigFlow(ConfigFlow, domain=DOMAIN):
                     return await self.async_step_predefined()
                 elif user_input.get(CONF_CONFIG_TYPE) == CONF_CONFIG_MULTI:
                     return await self.async_step_multi_step_1()
-                #return await self.async_step_repo()
+                # return await self.async_step_repo()
 
         return self.async_show_form(
             step_id="user", data_schema=BASE_CONFIG_SCHEMA, errors=errors
@@ -138,24 +144,29 @@ class UtilityMeterEvolvedCustomConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.data[CONF_CONFIG_CALIBRATE_CALC_APPLY] = None
                 self.data[CONF_CONFIG_CALIBRATE_CALC_VALUE] = 0
                 self.data[CONF_CONFIG_CALIBRATE_VALUE] = 0
-                self.data[CONF_CREATE_CALCULATION_SENSOR] = CONF_CREATE_CALCULATION_SENSOR_DEFAULT
+                self.data[CONF_CREATE_CALCULATION_SENSOR] = (
+                    CONF_CREATE_CALCULATION_SENSOR_DEFAULT
+                )
                 self.data[CONF_SOURCE_CALC_MULTIPLIER] = 1
-                self.data[CONF_METER_OFFSET] =(       # noqa: PGH003  # type: ignore
-                    CONF_METER_OFFSET_DURATION_DEFAULT)
-                self.data[CONF_METER_TYPE] = None   # noqa: PGH003# type: ignore
+                self.data[CONF_METER_OFFSET] = (  # noqa: PGH003  # type: ignore
+                    CONF_METER_OFFSET_DURATION_DEFAULT
+                )
+                self.data[CONF_METER_TYPE] = None  # noqa: PGH003# type: ignore
                 self.data[CONF_TARIFFS] = []  # noqa: PGH003 # type: ignore
-                self.data.update(user_input) # noqa: PGH003 # type: ignore
+                self.data.update(user_input)  # noqa: PGH003 # type: ignore
                 return self.async_create_entry(
                     title=self.data["name"],  # noqa: PGH003 # type: ignore
                     data={},
-                    options=self.data)   # noqa: PGH003 # type: ignore
+                    options=self.data,
+                )  # noqa: PGH003 # type: ignore
 
         return self.async_show_form(
-            step_id="cron", data_schema=create_cron_config_schema(self.data), errors=errors
+            step_id="cron",
+            data_schema=create_cron_config_schema(self.data),
+            errors=errors,
         )
 
-    async def async_step_predefined(self, user_input:
-            Optional[dict[str, Any]] = None):  # noqa: UP045
+    async def async_step_predefined(self, user_input: Optional[dict[str, Any]] = None):  # noqa: UP045
         """Second step in config flow to add a repo to watch."""
         errors: dict[str, str] = {}
         self.data = self.data or {}  # Initialize data if not set
@@ -174,21 +185,25 @@ class UtilityMeterEvolvedCustomConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.data[CONF_CONFIG_CALIBRATE_CALC_VALUE] = 0
                 self.data[CONF_CONFIG_CALIBRATE_VALUE] = 0
                 self.data[CONF_CONFIG_CRON] = None  # noqa: PGH003 # type: ignore
-                self.data[CONF_CREATE_CALCULATION_SENSOR] = CONF_CREATE_CALCULATION_SENSOR_DEFAULT
+                self.data[CONF_CREATE_CALCULATION_SENSOR] = (
+                    CONF_CREATE_CALCULATION_SENSOR_DEFAULT
+                )
                 self.data[CONF_SOURCE_CALC_MULTIPLIER] = 1
                 self.data[CONF_TARIFFS] = []  # noqa: PGH003 # type: ignore
                 self.data.update(user_input)  # noqa: PGH003 # type: ignore
-                return self.async_create_entry(title=self.data["name"],    # noqa: PGH003 # type: ignore
-                            data={}, options=self.data)
+                return self.async_create_entry(
+                    title=self.data["name"],  # noqa: PGH003 # type: ignore
+                    data={},
+                    options=self.data,
+                )
 
         return self.async_show_form(
             step_id="predefined",
             data_schema=create_predefined_config_schema(self.data),
-            errors=errors
+            errors=errors,
         )
 
-    async def async_step_multi_step_1(self, user_input:
-            Optional[dict[str, Any]] = None):  # noqa: UP045
+    async def async_step_multi_step_1(self, user_input: dict[str, Any] | None = None):
         """Second step in config flow to add a repo to watch."""
         errors: dict[str, str] = {}
         self.data = self.data or {}  # Initialize data if not set
@@ -206,7 +221,9 @@ class UtilityMeterEvolvedCustomConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.data[CONF_CONFIG_CALIBRATE_CALC_VALUE] = 0
                 self.data[CONF_CONFIG_CALIBRATE_VALUE] = 0
                 self.data[CONF_CONFIG_CRON] = None  # noqa: PGH003 # type: ignore
-                self.data[CONF_CREATE_CALCULATION_SENSOR] = CONF_CREATE_CALCULATION_SENSOR_DEFAULT
+                self.data[CONF_CREATE_CALCULATION_SENSOR] = (
+                    CONF_CREATE_CALCULATION_SENSOR_DEFAULT
+                )
                 self.data[CONF_SOURCE_CALC_MULTIPLIER] = 1
                 self.data[CONF_TARIFFS] = []  # noqa: PGH003 # type: ignore
                 self.data.update(user_input)  # noqa: PGH003 # type: ignore
@@ -215,10 +232,10 @@ class UtilityMeterEvolvedCustomConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="multi_step_1",
             data_schema=create_multi_config_schema_step_1(self.data),
-            errors=errors
+            errors=errors,
         )
-    async def async_step_multi_step_2(self, user_input:
-            Optional[dict[str, Any]] = None):    # noqa: UP045
+
+    async def async_step_multi_step_2(self, user_input: dict[str, Any] | None = None):
         """Second step in config flow to add a repo to watch."""
         errors: dict[str, str] = {}
         self.data = self.data or {}  # Initialize data if not set
@@ -233,40 +250,43 @@ class UtilityMeterEvolvedCustomConfigFlow(ConfigFlow, domain=DOMAIN):
             if not errors:
                 # Input is valid, set data.
                 if (
-                    (CONF_CONFIG_CALIBRATE_APPLY in user_input
-                    and user_input[CONF_CONFIG_CALIBRATE_APPLY] == "none")
-                    or (CONF_CONFIG_CALIBRATE_APPLY not in user_input)
-                ):
+                    CONF_CONFIG_CALIBRATE_APPLY in user_input
+                    and user_input[CONF_CONFIG_CALIBRATE_APPLY] == "none"
+                ) or (CONF_CONFIG_CALIBRATE_APPLY not in user_input):
                     user_input[CONF_CONFIG_CALIBRATE_APPLY] = None
                 if (
-                    (CONF_CONFIG_CALIBRATE_CALC_APPLY in user_input
-                    and user_input[CONF_CONFIG_CALIBRATE_CALC_APPLY] == "none")
-                    or (CONF_CONFIG_CALIBRATE_CALC_APPLY not in user_input)
-                ):
+                    CONF_CONFIG_CALIBRATE_CALC_APPLY in user_input
+                    and user_input[CONF_CONFIG_CALIBRATE_CALC_APPLY] == "none"
+                ) or (CONF_CONFIG_CALIBRATE_CALC_APPLY not in user_input):
                     user_input[CONF_CONFIG_CALIBRATE_CALC_APPLY] = None
                 self.data.update(user_input)  # noqa: PGH003 # type: ignore
-                return self.async_create_entry(title=self.data["name"],    # noqa: PGH003 # type: ignore
-                            data={}, options=self.data)
+                return self.async_create_entry(
+                    title=self.data["name"],  # noqa: PGH003 # type: ignore
+                    data={},
+                    options=self.data,
+                )
 
         return self.async_show_form(
             step_id="multi_step_2",
             data_schema=create_multi_config_schema_step_2(self.data),
-            errors=errors
+            errors=errors,
         )
+
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
         return OptionsFlowHandler(config_entry)
 
+
 class OptionsFlowHandler(OptionsFlow):
     """Handles options flow for the component."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize the options flow handler."""
-        self.options_schema =None
+        self.options_schema = None
         self.config_type = None
-        self.data = config_entry.options.copy()  #noqa: PGH003 # type: ignore
+        self.data = config_entry.options.copy()  # noqa: PGH003 # type: ignore
         _LOGGER.debug("async Option init self.data: %s", self.data)
         if config_entry.options["config_type"] == CONF_CONFIG_CRON:
             self.config_type = CONF_CONFIG_CRON
@@ -279,10 +299,12 @@ class OptionsFlowHandler(OptionsFlow):
         elif config_entry.options["config_type"] == CONF_CONFIG_MULTI:
             self.config_type = CONF_CONFIG_MULTI
             # Create the options schema for multi config.
-            self.options_schema = create_multi_option_schema_step_2(config_entry.options)
+            self.options_schema = create_multi_option_schema_step_2(
+                config_entry.options
+            )
 
     @staticmethod
-    def _validate_state(state: State | None) -> Decimal | None: # noqa: F821
+    def _validate_state(state: State | None) -> Decimal | None:  # noqa: F821
         """Parse the state as a Decimal if available. Throws DecimalException if not a number."""
         try:
             return (
@@ -293,15 +315,12 @@ class OptionsFlowHandler(OptionsFlow):
         except DecimalException:
             return None
 
-
-    async def async_step_init(
-        self, user_input = None
-    ):
+    async def async_step_init(self, user_input=None):
         """Manage the options for the custom component."""
         errors: dict[str, str] = {}
         if user_input is not None:
             # Get the current repos from the config entry.
-            if CONF_REMOVE_CALC_SENSOR in user_input: # sourcery skip: merge-nested-ifs
+            if CONF_REMOVE_CALC_SENSOR in user_input:  # sourcery skip: merge-nested-ifs
                 if user_input[CONF_REMOVE_CALC_SENSOR]:
                     # Remove the calc sensor from the options.
                     user_input[CONF_SOURCE_CALC_SENSOR] = None
@@ -310,7 +329,9 @@ class OptionsFlowHandler(OptionsFlow):
             try:
                 if CONF_SOURCE_CALC_SENSOR in user_input:
                     if user_input[CONF_SOURCE_CALC_SENSOR] is not None:
-                        source_state = self.hass.states.get(user_input[CONF_SOURCE_CALC_SENSOR])
+                        source_state = self.hass.states.get(
+                            user_input[CONF_SOURCE_CALC_SENSOR]
+                        )
                         if source_state is None:
                             errors["base"] = "source_calc_sensor_not_found"
                         elif source_state.state in [STATE_UNAVAILABLE, STATE_UNKNOWN]:
@@ -332,7 +353,7 @@ class OptionsFlowHandler(OptionsFlow):
                 user_input[CONF_CONFIG_CALIBRATE_APPLY] = None
                 user_input[CONF_CONFIG_CALIBRATE_CALC_APPLY] = None
                 user_input[CONF_CONFIG_TYPE] = CONF_CONFIG_CRON
-                user_input[CONF_METER_OFFSET] =CONF_METER_OFFSET_DURATION_DEFAULT
+                user_input[CONF_METER_OFFSET] = CONF_METER_OFFSET_DURATION_DEFAULT
                 user_input[CONF_METER_TYPE] = None
             elif self.data["config_type"] == CONF_CONFIG_PREDEFINED:
                 user_input[CONF_CONFIG_CALIBRATE_APPLY] = None
@@ -343,30 +364,30 @@ class OptionsFlowHandler(OptionsFlow):
                 user_input[CONF_CONFIG_CRON] = None
                 user_input[CONF_CONFIG_TYPE] = CONF_CONFIG_MULTI
                 user_input[CONF_METER_OFFSET] = CONF_METER_OFFSET_DURATION_DEFAULT
-                #user_input[CONF_TARIFFS] = []  # noqa: PGH003 # type: ignore
+                # user_input[CONF_TARIFFS] = []  # noqa: PGH003 # type: ignore
 
             _LOGGER.debug("async Option step 1 self.data: %s", self.data)
 
-            #if self.data["config_type"] == CONF_CONFIG_MULTI:
+            # if self.data["config_type"] == CONF_CONFIG_MULTI:
             #    return await self.async_multi_option_step_2()
 
             _LOGGER.debug("async Option NOT MULTI: %s", self.data["config_type"])
-            return self.async_create_entry(title=self.config_entry.title, data=user_input)
+            return self.async_create_entry(
+                title=self.config_entry.title, data=user_input
+            )
             # For multi config, we need to show the next step.
-            #self.data = user_input
-            #return await self.async_multi_step_2()
-        #options_schema = OPTIONS_SCHEMA
+            # self.data = user_input
+            # return await self.async_multi_step_2()
+        # options_schema = OPTIONS_SCHEMA
         _LOGGER.debug("async Option init schema: %s", self.options_schema)
         return self.async_show_form(
-            step_id="init",
-            data_schema=self.options_schema,
-            errors=errors
+            step_id="init", data_schema=self.options_schema, errors=errors
         )
 
-    async def async_multi_option_step_2(self, user_input = None):
+    async def async_multi_option_step_2(self, user_input=None):
         """Second step in config flow to add a repo to watch."""
-        #errors: dict[str, str] = {}
-        #self.data = self.data or {}  # Initialize data if not set
+        # errors: dict[str, str] = {}
+        # self.data = self.data or {}  # Initialize data if not set
         _LOGGER.debug("async Option step 2 self.data: %s", self.data)
         if user_input is not None:
             # Validate the path.
@@ -375,11 +396,12 @@ class OptionsFlowHandler(OptionsFlow):
             # Input is valid, set data.
             self.data.update(user_input)  # noqa: PGH003 # type: ignore
             return self.async_create_entry(
-                title=self.config_entry.title,
-                data=self.data
+                title=self.config_entry.title, data=self.data
             )
-        _LOGGER.debug("async Option step 2 schema: %s", create_multi_option_schema_step_2(self.data))
+        _LOGGER.debug(
+            "async Option step 2 schema: %s",
+            create_multi_option_schema_step_2(self.data),
+        )
         return self.async_show_form(
-            step_id="init_2",
-            data_schema=create_multi_option_schema_step_2(self.data)
+            step_id="init_2", data_schema=create_multi_option_schema_step_2(self.data)
         )

--- a/custom_components/utility_meter_next_gen/const.py
+++ b/custom_components/utility_meter_next_gen/const.py
@@ -106,7 +106,7 @@ CONF_CRON_PATTERN = "cron"
 CONF_METER = "meter"
 CONF_METER_TYPE = "cycle"
 CONF_METER_OFFSET = "offset"
-CONF_METER_OFFSET_DURATION_DEFAULT = {"days":0, "hours":0, "minutes":0, "seconds":0}
+CONF_METER_OFFSET_DURATION_DEFAULT = {"days": 0, "hours": 0, "minutes": 0, "seconds": 0}
 CONF_METER_DELTA_VALUES = "delta_values"
 CONF_METER_NET_CONSUMPTION = "net_consumption"
 CONF_METER_PERIODICALLY_RESETTING = "periodically_resetting"
@@ -140,7 +140,7 @@ CONF_METER_TYPES = [
     YEARLY,
 ]
 
-#Entity related constants
+# Entity related constants
 ATTR_CALC_CURRENT_VALUE = "current_period_calculated_value"
 ATTR_CALC_LAST_VALUE = "last_period_calculated_value"
 ATTR_CRON_PATTERN = "cron pattern"
@@ -159,7 +159,7 @@ ATTR_VALUE = "value"
 SIGNAL_START_PAUSE_METER = "utility_meter_next_gen_start_pause"
 SIGNAL_RESET_METER = "utility_meter_next_gen_reset"
 
-#Action related constants
+# Action related constants
 SERVICE_RESET = "reset"
 SERVICE_CALIBRATE_METER = "calibrate"
 
@@ -175,7 +175,7 @@ DEVICE_CLASSES_METER = [
     "volume",
     "volume_storage",
     "water",
-    "weight"
+    "weight",
 ]
 
 PERIOD2CRON = {

--- a/custom_components/utility_meter_next_gen/manifest.json
+++ b/custom_components/utility_meter_next_gen/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/cabberley/utility_meter_evolved/issues",
   "requirements": ["cronsim==2.7"],
   "ssdp": [],
-  "version": "2026.5.1",
+  "version": "2026.8.0",
   "zeroconf": []
 }

--- a/custom_components/utility_meter_next_gen/schemas.py
+++ b/custom_components/utility_meter_next_gen/schemas.py
@@ -1,4 +1,5 @@
 """Schemas for configuring the Utility Meter Next Gen component."""
+
 import logging
 
 import voluptuous as vol
@@ -42,18 +43,21 @@ BASE_CONFIG_SCHEMA = vol.Schema(
         vol.Required(CONF_NAME): selector.TextSelector(),
         vol.Required(CONF_SOURCE_SENSOR): selector.EntitySelector(
             selector.EntitySelectorConfig(
-                domain=SENSOR_DOMAIN, filter={"device_class": DEVICE_CLASSES_METER}),
+                domain=SENSOR_DOMAIN, filter={"device_class": DEVICE_CLASSES_METER}
+            ),
         ),
         vol.Optional(CONF_SOURCE_CALC_SENSOR): selector.EntitySelector(
             selector.EntitySelectorConfig(domain=SENSOR_DOMAIN),
         ),
-        vol.Required(CONF_CONFIG_TYPE, default=[CONF_CONFIG_PREDEFINED]): selector.SelectSelector(
+        vol.Required(
+            CONF_CONFIG_TYPE, default=[CONF_CONFIG_PREDEFINED]
+        ): selector.SelectSelector(
             selector.SelectSelectorConfig(
                 options=CONFIG_TYPES,
                 translation_key=CONF_CONFIG_TYPE,
                 mode=selector.SelectSelectorMode.LIST,
-                custom_value =False,
-                multiple=False
+                custom_value=False,
+                multiple=False,
             ),
         ),
     }
@@ -63,12 +67,12 @@ BASE_PREDEFINED_CONFIG_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_METER_TYPE): selector.SelectSelector(
             selector.SelectSelectorConfig(
-                options=METER_TYPES,
-                translation_key=CONF_METER_TYPE
+                options=METER_TYPES, translation_key=CONF_METER_TYPE
             ),
         ),
-        vol.Optional(CONF_METER_OFFSET,
-            default=CONF_METER_OFFSET_DURATION_DEFAULT): selector.DurationSelector(
+        vol.Optional(
+            CONF_METER_OFFSET, default=CONF_METER_OFFSET_DURATION_DEFAULT
+        ): selector.DurationSelector(
             selector.DurationSelectorConfig(
                 enable_day=True,
             ),
@@ -84,150 +88,139 @@ BASE_CRON_CONFIG_SCHEMA = vol.Schema(
 
 BASE_MULTI_CONFIG_SCHEMA_STEP_1 = vol.Schema(
     {
-        vol.Required(CONF_METER_TYPE,default=[]): selector.SelectSelector(
+        vol.Required(CONF_METER_TYPE, default=[]): selector.SelectSelector(
             selector.SelectSelectorConfig(
                 options=MULTI_METER_TYPES,
                 translation_key=CONF_METER_TYPE,
                 mode=selector.SelectSelectorMode.DROPDOWN,
-                custom_value =False,
-                multiple=True
+                custom_value=False,
+                multiple=True,
             ),
         ),
     }
 )
 
 BASE_COMMON_CONFIG_SCHEMA = {
-        vol.Optional(
-            CONF_CONFIG_CALIBRATE_VALUE,
-            default=0
-            ): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                mode=selector.NumberSelectorMode.BOX,
-                step="any",
-                    ),
+    vol.Optional(CONF_CONFIG_CALIBRATE_VALUE, default=0): selector.NumberSelector(
+        selector.NumberSelectorConfig(
+            mode=selector.NumberSelectorMode.BOX,
+            step="any",
         ),
-        vol.Required(CONF_TARIFFS, default=[]): selector.SelectSelector(
-            selector.SelectSelectorConfig(options=[], custom_value=True, multiple=True),
-        ),
-        vol.Required(
-            CONF_METER_NET_CONSUMPTION, default=False
-        ): selector.BooleanSelector(),
-        vol.Required(
-            CONF_METER_DELTA_VALUES, default=False
-        ): selector.BooleanSelector(),
-        vol.Required(
-            CONF_METER_PERIODICALLY_RESETTING,
-            default=True,
-        ): selector.BooleanSelector(),
-        vol.Optional(
-            CONF_SENSOR_ALWAYS_AVAILABLE,
-            default=True,
-        ): selector.BooleanSelector(),
+    ),
+    vol.Required(CONF_TARIFFS, default=[]): selector.SelectSelector(
+        selector.SelectSelectorConfig(options=[], custom_value=True, multiple=True),
+    ),
+    vol.Required(CONF_METER_NET_CONSUMPTION, default=False): selector.BooleanSelector(),
+    vol.Required(CONF_METER_DELTA_VALUES, default=False): selector.BooleanSelector(),
+    vol.Required(
+        CONF_METER_PERIODICALLY_RESETTING,
+        default=True,
+    ): selector.BooleanSelector(),
+    vol.Optional(
+        CONF_SENSOR_ALWAYS_AVAILABLE,
+        default=True,
+    ): selector.BooleanSelector(),
 }
+
+
 def create_calc_extras_schema(data):
     """Create the calibration schema for predefined and cron cycles."""
-    calibrate_default = data.get(CONF_CONFIG_CALIBRATE_CALC_VALUE,0)
+    calibrate_default = data.get(CONF_CONFIG_CALIBRATE_CALC_VALUE, 0)
     multiplier_default = data.get(CONF_SOURCE_CALC_MULTIPLIER, 1)
-    create_calc_sensor_default = data.get(CONF_CREATE_CALCULATION_SENSOR,
-            CONF_CREATE_CALCULATION_SENSOR_DEFAULT)
+    create_calc_sensor_default = data.get(
+        CONF_CREATE_CALCULATION_SENSOR, CONF_CREATE_CALCULATION_SENSOR_DEFAULT
+    )
     if data[CONF_SOURCE_CALC_SENSOR] is not None:
         return {
             vol.Required(
-                CONF_CREATE_CALCULATION_SENSOR,
-                default=create_calc_sensor_default):
-                    selector.BooleanSelector(
-                        selector.BooleanSelectorConfig()
-                ),
+                CONF_CREATE_CALCULATION_SENSOR, default=create_calc_sensor_default
+            ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
             vol.Required(
                 CONF_SOURCE_CALC_MULTIPLIER, default=multiplier_default
-                ): selector.NumberSelector(
+            ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     mode=selector.NumberSelectorMode.BOX,
                     step="any",
-                    ),
                 ),
+            ),
             vol.Optional(
-                CONF_CONFIG_CALIBRATE_CALC_VALUE,
-                default=calibrate_default): selector.NumberSelector(
+                CONF_CONFIG_CALIBRATE_CALC_VALUE, default=calibrate_default
+            ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     mode=selector.NumberSelectorMode.BOX,
                     step="any",
-                        ),
                 ),
-            }
+            ),
+        }
     return {}
+
 
 def create_common_multi_config_schema_step_2a(data):
     """Create the common configuration schema for multi configurations."""
     return vol.Schema(
         {
-        vol.Optional(
-            CONF_CONFIG_CALIBRATE_VALUE,
-            default=0
+            vol.Optional(
+                CONF_CONFIG_CALIBRATE_VALUE, default=0
             ): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                mode=selector.NumberSelectorMode.BOX,
-                step="any",
-                    ),
-        ),
-        vol.Optional(
-                CONF_CONFIG_CALIBRATE_APPLY):
-                    selector.SelectSelector(
-                    selector.SelectSelectorConfig(
+                selector.NumberSelectorConfig(
+                    mode=selector.NumberSelectorMode.BOX,
+                    step="any",
+                ),
+            ),
+            vol.Optional(CONF_CONFIG_CALIBRATE_APPLY): selector.SelectSelector(
+                selector.SelectSelectorConfig(
                     options=data.get(CONF_METER_TYPE, []),
                     translation_key=CONF_METER_TYPE,
                     mode=selector.SelectSelectorMode.DROPDOWN,
-                    custom_value =False,
-                    multiple=False
+                    custom_value=False,
+                    multiple=False,
                 ),
             ),
         }
     )
 
+
 def create_common_multi_config_schema_step_2b(data):
     """Create the calibration schema for multi cycles."""
-    calibrate_default = data.get(CONF_CONFIG_CALIBRATE_CALC_VALUE,0)
+    calibrate_default = data.get(CONF_CONFIG_CALIBRATE_CALC_VALUE, 0)
     multiplier_default = data.get(CONF_SOURCE_CALC_MULTIPLIER, 1)
     selected_meter_types = data.get(CONF_METER_TYPE, [])
-    create_calc_sensor_default = data.get(CONF_CREATE_CALCULATION_SENSOR,
-        CONF_CREATE_CALCULATION_SENSOR_DEFAULT)
+    create_calc_sensor_default = data.get(
+        CONF_CREATE_CALCULATION_SENSOR, CONF_CREATE_CALCULATION_SENSOR_DEFAULT
+    )
     if data[CONF_SOURCE_CALC_SENSOR] is not None:
         return {
             vol.Required(
-                CONF_CREATE_CALCULATION_SENSOR,
-                default=create_calc_sensor_default):
-                    selector.BooleanSelector(
-                        selector.BooleanSelectorConfig()
-                ),
+                CONF_CREATE_CALCULATION_SENSOR, default=create_calc_sensor_default
+            ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
             vol.Required(
                 CONF_SOURCE_CALC_MULTIPLIER, default=multiplier_default
-                ): selector.NumberSelector(
+            ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     mode=selector.NumberSelectorMode.BOX,
                     step="any",
-                    ),
                 ),
+            ),
             vol.Required(
-                CONF_CONFIG_CALIBRATE_CALC_VALUE,
-                default=calibrate_default): selector.NumberSelector(
+                CONF_CONFIG_CALIBRATE_CALC_VALUE, default=calibrate_default
+            ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     mode=selector.NumberSelectorMode.BOX,
                     step="any",
-                        ),
                 ),
-            vol.Optional(
-                CONF_CONFIG_CALIBRATE_CALC_APPLY):
-                    selector.SelectSelector(
-                    selector.SelectSelectorConfig(
+            ),
+            vol.Optional(CONF_CONFIG_CALIBRATE_CALC_APPLY): selector.SelectSelector(
+                selector.SelectSelectorConfig(
                     options=selected_meter_types,
                     translation_key=CONF_METER_TYPE,
                     mode=selector.SelectSelectorMode.DROPDOWN,
-                    custom_value =False,
-                    multiple=False
-                    ),
+                    custom_value=False,
+                    multiple=False,
                 ),
-            }
+            ),
+        }
     return {}
+
 
 def create_common_multi_config_schema_step_2c():
     """Create the common configuration schema for multi configurations."""
@@ -249,7 +242,8 @@ def create_common_multi_config_schema_step_2c():
             CONF_SENSOR_ALWAYS_AVAILABLE,
             default=True,
         ): selector.BooleanSelector(),
-}
+    }
+
 
 def create_predefined_config_schema(data):
     """Create the configuration schema for predefined cycles."""
@@ -258,9 +252,10 @@ def create_predefined_config_schema(data):
         {
             **BASE_PREDEFINED_CONFIG_SCHEMA.schema,
             **(create_calc_extras_schema(data) or {}),
-            **BASE_COMMON_CONFIG_SCHEMA
+            **BASE_COMMON_CONFIG_SCHEMA,
         }
     )
+
 
 def create_cron_config_schema(data):
     """Create the configuration schema for predefined cycles."""
@@ -269,9 +264,10 @@ def create_cron_config_schema(data):
         {
             **BASE_CRON_CONFIG_SCHEMA.schema,
             **(create_calc_extras_schema(data) or {}),
-            **BASE_COMMON_CONFIG_SCHEMA
+            **BASE_COMMON_CONFIG_SCHEMA,
         }
     )
+
 
 def create_multi_config_schema_step_1(data):
     """Create the configuration schema for predefined cycles."""
@@ -282,6 +278,7 @@ def create_multi_config_schema_step_1(data):
         }
     )
 
+
 def create_multi_config_schema_step_2(data):
     """Create the configuration schema for predefined cycles."""
 
@@ -289,74 +286,79 @@ def create_multi_config_schema_step_2(data):
         {
             **(create_common_multi_config_schema_step_2a(data)).schema,
             **create_common_multi_config_schema_step_2b(data),
-            **create_common_multi_config_schema_step_2c()
+            **create_common_multi_config_schema_step_2c(),
         }
     )
+
 
 def create_base_predefined_option_schema(data):
     """Create the base options schema for predefined cycles."""
 
     return {
-        vol.Required(CONF_METER_TYPE, default=data[CONF_METER_TYPE]): selector.SelectSelector(
+        vol.Required(
+            CONF_METER_TYPE, default=data[CONF_METER_TYPE]
+        ): selector.SelectSelector(
             selector.SelectSelectorConfig(
                 options=METER_TYPES, translation_key=CONF_METER_TYPE
             ),
         ),
-        vol.Optional(CONF_METER_OFFSET,
-            default=data[CONF_METER_OFFSET]): selector.DurationSelector(
+        vol.Optional(
+            CONF_METER_OFFSET, default=data[CONF_METER_OFFSET]
+        ): selector.DurationSelector(
             selector.DurationSelectorConfig(
                 enable_day=True,
             ),
         ),
     }
 
+
 def create_base_cron_option_schema(data):
     """Create the base options schema for cron cycles."""
 
     return {
-        vol.Required(CONF_CONFIG_CRON, default=data[CONF_CONFIG_CRON]): selector.TextSelector(),
+        vol.Required(
+            CONF_CONFIG_CRON, default=data[CONF_CONFIG_CRON]
+        ): selector.TextSelector(),
     }
+
 
 def create_common_option_schema(data):
     """Create the common options schema for all configurations."""
     option_schema = {
         vol.Required(
             CONF_CREATE_CALCULATION_SENSOR,
-            default=data[CONF_CREATE_CALCULATION_SENSOR],):
-                selector.BooleanSelector(
-                    selector.BooleanSelectorConfig()
-            ),
+            default=data[CONF_CREATE_CALCULATION_SENSOR],
+        ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
         vol.Optional(
-            CONF_CONFIG_CALIBRATE_VALUE,
-            default=data[CONF_CONFIG_CALIBRATE_VALUE]): selector.NumberSelector(
+            CONF_CONFIG_CALIBRATE_VALUE, default=data[CONF_CONFIG_CALIBRATE_VALUE]
+        ): selector.NumberSelector(
             selector.NumberSelectorConfig(
                 mode=selector.NumberSelectorMode.BOX,
                 step="any",
-                    ),
+            ),
         ),
         vol.Optional(
             CONF_CONFIG_CALIBRATE_CALC_VALUE,
-            default=data.get(CONF_CONFIG_CALIBRATE_CALC_VALUE,0)): selector.NumberSelector(
+            default=data.get(CONF_CONFIG_CALIBRATE_CALC_VALUE, 0),
+        ): selector.NumberSelector(
             selector.NumberSelectorConfig(
                 mode=selector.NumberSelectorMode.BOX,
                 step="any",
-                    ),
+            ),
         ),
     }
     if data[CONF_TARIFFS] != [] and data[CONF_TARIFFS] is not None:
-        _LOGGER.debug("Schema Current Tariffs: %s", data[CONF_TARIFFS] )
-        option_schema[
-            vol.Required(CONF_TARIFFS, default=data[CONF_TARIFFS])
-        ] = selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=[], custom_value=True, multiple=True
-            ),
+        _LOGGER.debug("Schema Current Tariffs: %s", data[CONF_TARIFFS])
+        option_schema[vol.Required(CONF_TARIFFS, default=data[CONF_TARIFFS])] = (
+            selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[], custom_value=True, multiple=True
+                ),
+            )
         )
     else:
-        _LOGGER.debug("Schema Current Tariffs: %s", data[CONF_TARIFFS] )
-        option_schema[
-            vol.Optional(CONF_TARIFFS)
-        ] = selector.SelectSelector(
+        _LOGGER.debug("Schema Current Tariffs: %s", data[CONF_TARIFFS])
+        option_schema[vol.Optional(CONF_TARIFFS)] = selector.SelectSelector(
             selector.SelectSelectorConfig(
                 options=[], custom_value=False, multiple=False
             ),
@@ -382,18 +384,22 @@ def create_common_option_schema(data):
     }
     return option_schema
 
+
 def create_predefined_option_schema(data):
     """Create the options schema for predefined cycles."""
 
     if data[CONF_SOURCE_CALC_SENSOR] is None:
         predefined_begin = vol.Schema(
             {
-                vol.Required(CONF_SOURCE_SENSOR,
-                    default=data[CONF_SOURCE_SENSOR]): selector.EntitySelector(
+                vol.Required(
+                    CONF_SOURCE_SENSOR, default=data[CONF_SOURCE_SENSOR]
+                ): selector.EntitySelector(
                     selector.EntitySelectorConfig(
-                        domain=SENSOR_DOMAIN, filter={"device_class": DEVICE_CLASSES_METER}),
+                        domain=SENSOR_DOMAIN,
+                        filter={"device_class": DEVICE_CLASSES_METER},
+                    ),
                 ),
-                vol.Optional(CONF_SOURCE_CALC_SENSOR ): selector.EntitySelector(
+                vol.Optional(CONF_SOURCE_CALC_SENSOR): selector.EntitySelector(
                     selector.EntitySelectorConfig(domain=SENSOR_DOMAIN),
                 ),
                 vol.Required(
@@ -402,44 +408,50 @@ def create_predefined_option_schema(data):
                     selector.NumberSelectorConfig(
                         mode=selector.NumberSelectorMode.BOX,
                         step="any",
-                        ),
+                    ),
                 ),
             }
         )
     else:
         predefined_begin = vol.Schema(
             {
-                vol.Required(CONF_SOURCE_SENSOR,
-                    default=data[CONF_SOURCE_SENSOR]): selector.EntitySelector(
+                vol.Required(
+                    CONF_SOURCE_SENSOR, default=data[CONF_SOURCE_SENSOR]
+                ): selector.EntitySelector(
                     selector.EntitySelectorConfig(
-                        domain=SENSOR_DOMAIN, filter={"device_class": DEVICE_CLASSES_METER}),
+                        domain=SENSOR_DOMAIN,
+                        filter={"device_class": DEVICE_CLASSES_METER},
+                    ),
                 ),
                 vol.Optional(
                     CONF_REMOVE_CALC_SENSOR,
                     default=False,
                 ): selector.BooleanSelector(),
-                vol.Optional(CONF_SOURCE_CALC_SENSOR,
-                    default=data[CONF_SOURCE_CALC_SENSOR] ): selector.EntitySelector(
+                vol.Optional(
+                    CONF_SOURCE_CALC_SENSOR, default=data[CONF_SOURCE_CALC_SENSOR]
+                ): selector.EntitySelector(
                     selector.EntitySelectorConfig(domain=SENSOR_DOMAIN),
                 ),
                 vol.Required(
-                    CONF_SOURCE_CALC_MULTIPLIER, default=data[CONF_SOURCE_CALC_MULTIPLIER]
+                    CONF_SOURCE_CALC_MULTIPLIER,
+                    default=data[CONF_SOURCE_CALC_MULTIPLIER],
                 ): selector.NumberSelector(
                     selector.NumberSelectorConfig(
                         mode=selector.NumberSelectorMode.BOX,
                         step="any",
-                        ),
+                    ),
                 ),
-
             }
         )
     return vol.Schema(
-        {**predefined_begin.schema,
+        {
+            **predefined_begin.schema,
             **create_base_predefined_option_schema(data),
-            #**(create_calc_extras_schema(data) or {}),
-            **create_common_option_schema(data)
+            # **(create_calc_extras_schema(data) or {}),
+            **create_common_option_schema(data),
         }
     )
+
 
 def create_cron_option_schema(data):
     """Create the options schema for cron cycles."""
@@ -447,12 +459,15 @@ def create_cron_option_schema(data):
     if data[CONF_SOURCE_CALC_SENSOR] is None:
         cron_begin = vol.Schema(
             {
-                vol.Required(CONF_SOURCE_SENSOR,
-                    default=data[CONF_SOURCE_SENSOR]): selector.EntitySelector(
+                vol.Required(
+                    CONF_SOURCE_SENSOR, default=data[CONF_SOURCE_SENSOR]
+                ): selector.EntitySelector(
                     selector.EntitySelectorConfig(
-                        domain=SENSOR_DOMAIN, filter={"device_class": DEVICE_CLASSES_METER}),
+                        domain=SENSOR_DOMAIN,
+                        filter={"device_class": DEVICE_CLASSES_METER},
+                    ),
                 ),
-                vol.Optional(CONF_SOURCE_CALC_SENSOR ): selector.EntitySelector(
+                vol.Optional(CONF_SOURCE_CALC_SENSOR): selector.EntitySelector(
                     selector.EntitySelectorConfig(domain=SENSOR_DOMAIN),
                 ),
                 vol.Required(
@@ -461,160 +476,173 @@ def create_cron_option_schema(data):
                     selector.NumberSelectorConfig(
                         mode=selector.NumberSelectorMode.BOX,
                         step="any",
-                        ),
+                    ),
                 ),
-
             }
         )
     else:
         cron_begin = vol.Schema(
             {
-                vol.Required(CONF_SOURCE_SENSOR,
-                    default=data[CONF_SOURCE_SENSOR]): selector.EntitySelector(
+                vol.Required(
+                    CONF_SOURCE_SENSOR, default=data[CONF_SOURCE_SENSOR]
+                ): selector.EntitySelector(
                     selector.EntitySelectorConfig(
-                        domain=SENSOR_DOMAIN, filter={"device_class": DEVICE_CLASSES_METER}),
+                        domain=SENSOR_DOMAIN,
+                        filter={"device_class": DEVICE_CLASSES_METER},
+                    ),
                 ),
                 vol.Optional(
                     CONF_REMOVE_CALC_SENSOR,
                     default=False,
                 ): selector.BooleanSelector(),
-                vol.Optional(CONF_SOURCE_CALC_SENSOR,
-                    default=data[CONF_SOURCE_CALC_SENSOR] ): selector.EntitySelector(
+                vol.Optional(
+                    CONF_SOURCE_CALC_SENSOR, default=data[CONF_SOURCE_CALC_SENSOR]
+                ): selector.EntitySelector(
                     selector.EntitySelectorConfig(domain=SENSOR_DOMAIN),
                 ),
                 vol.Required(
-                    CONF_SOURCE_CALC_MULTIPLIER, default=data[CONF_SOURCE_CALC_MULTIPLIER]
+                    CONF_SOURCE_CALC_MULTIPLIER,
+                    default=data[CONF_SOURCE_CALC_MULTIPLIER],
                 ): selector.NumberSelector(
                     selector.NumberSelectorConfig(
                         mode=selector.NumberSelectorMode.BOX,
                         step="any",
-                        ),
+                    ),
                 ),
             }
         )
     return vol.Schema(
-        {**cron_begin.schema,
+        {
+            **cron_begin.schema,
             **create_base_cron_option_schema(data),
-            **create_common_option_schema(data)
+            **create_common_option_schema(data),
         }
     )
+
 
 def create_multi_option_schema_step_1(data):
     """Create the options step 1 schema for multi configurations."""
     if data[CONF_SOURCE_CALC_SENSOR] is None:
         multi_option_step_1 = vol.Schema(
             {
-                vol.Required(CONF_SOURCE_SENSOR,
-                    default=data[CONF_SOURCE_SENSOR]): selector.EntitySelector(
+                vol.Required(
+                    CONF_SOURCE_SENSOR, default=data[CONF_SOURCE_SENSOR]
+                ): selector.EntitySelector(
                     selector.EntitySelectorConfig(
-                        domain=SENSOR_DOMAIN, filter={"device_class": DEVICE_CLASSES_METER}),
+                        domain=SENSOR_DOMAIN,
+                        filter={"device_class": DEVICE_CLASSES_METER},
+                    ),
                 ),
-                vol.Optional(CONF_SOURCE_CALC_SENSOR ): selector.EntitySelector(
+                vol.Optional(CONF_SOURCE_CALC_SENSOR): selector.EntitySelector(
                     selector.EntitySelectorConfig(domain=SENSOR_DOMAIN),
                 ),
                 vol.Required(
                     CONF_CREATE_CALCULATION_SENSOR,
-                    default=data[CONF_CREATE_CALCULATION_SENSOR]):
-                        selector.BooleanSelector(
-                            selector.BooleanSelectorConfig()
-                ),
+                    default=data[CONF_CREATE_CALCULATION_SENSOR],
+                ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
                 vol.Required(
                     CONF_SOURCE_CALC_MULTIPLIER, default=1
                 ): selector.NumberSelector(
                     selector.NumberSelectorConfig(
                         mode=selector.NumberSelectorMode.BOX,
                         step="any",
-                        ),
+                    ),
                 ),
             }
         )
     else:
         multi_option_step_1 = vol.Schema(
             {
-                vol.Required(CONF_SOURCE_SENSOR,
-                    default=data[CONF_SOURCE_SENSOR]): selector.EntitySelector(
+                vol.Required(
+                    CONF_SOURCE_SENSOR, default=data[CONF_SOURCE_SENSOR]
+                ): selector.EntitySelector(
                     selector.EntitySelectorConfig(
-                        domain=SENSOR_DOMAIN, filter={"device_class": DEVICE_CLASSES_METER}),
+                        domain=SENSOR_DOMAIN,
+                        filter={"device_class": DEVICE_CLASSES_METER},
+                    ),
                 ),
-                vol.Optional(CONF_SOURCE_CALC_SENSOR,
-                    default=data[CONF_SOURCE_CALC_SENSOR] ): selector.EntitySelector(
+                vol.Optional(
+                    CONF_SOURCE_CALC_SENSOR, default=data[CONF_SOURCE_CALC_SENSOR]
+                ): selector.EntitySelector(
                     selector.EntitySelectorConfig(domain=SENSOR_DOMAIN),
                 ),
                 vol.Required(
                     CONF_CREATE_CALCULATION_SENSOR,
-                    default=data[CONF_CREATE_CALCULATION_SENSOR]):
-                        selector.BooleanSelector(
-                            selector.BooleanSelectorConfig()
-                ),
+                    default=data[CONF_CREATE_CALCULATION_SENSOR],
+                ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
                 vol.Required(
                     CONF_REMOVE_CALC_SENSOR,
                     default=False,
                 ): selector.BooleanSelector(),
                 vol.Required(
-                    CONF_SOURCE_CALC_MULTIPLIER, default=data[CONF_SOURCE_CALC_MULTIPLIER]
+                    CONF_SOURCE_CALC_MULTIPLIER,
+                    default=data[CONF_SOURCE_CALC_MULTIPLIER],
                 ): selector.NumberSelector(
                     selector.NumberSelectorConfig(
                         mode=selector.NumberSelectorMode.BOX,
                         step="any",
-                        ),
+                    ),
                 ),
-
             }
         )
-    meter_types ={
-        vol.Required(CONF_METER_TYPE,default=data[CONF_METER_TYPE]): selector.SelectSelector(
+    meter_types = {
+        vol.Required(
+            CONF_METER_TYPE, default=data[CONF_METER_TYPE]
+        ): selector.SelectSelector(
             selector.SelectSelectorConfig(
                 options=METER_TYPES,
                 translation_key=CONF_METER_TYPE,
                 mode=selector.SelectSelectorMode.DROPDOWN,
-                custom_value =False,
-                multiple=True
+                custom_value=False,
+                multiple=True,
             ),
         ),
     }
     if data[CONF_TARIFFS] != [] and data[CONF_TARIFFS] is not None:
-        _LOGGER.debug("Schema Current Tariffs: %s", data[CONF_TARIFFS] )
+        _LOGGER.debug("Schema Current Tariffs: %s", data[CONF_TARIFFS])
         multi_option_step_tariffs = {
-            vol.Optional(CONF_TARIFFS, default=data[CONF_TARIFFS]):
-            selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=[], custom_value=True, multiple=True
-            ),
+            vol.Optional(
+                CONF_TARIFFS, default=data[CONF_TARIFFS]
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[], custom_value=True, multiple=True
+                ),
             )
         }
     else:
-        _LOGGER.debug("Schema Current Tariffs: %s", data[CONF_TARIFFS] )
+        _LOGGER.debug("Schema Current Tariffs: %s", data[CONF_TARIFFS])
         multi_option_step_tariffs = {}
 
     return vol.Schema(
-        {**multi_option_step_1.schema,
+        {
+            **multi_option_step_1.schema,
             **meter_types,
             **multi_option_step_tariffs,
         }
     )
 
+
 def create_multi_option_schema_step_2(data):
     """Create the options step 2 schema for multi configurations."""
     multi_option_step_2 = vol.Schema(
         {
-        vol.Optional(
-            CONF_CONFIG_CALIBRATE_VALUE,
-            default=data[CONF_CONFIG_CALIBRATE_VALUE]): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                mode=selector.NumberSelectorMode.BOX,
-                step="any",
-                    ),
-        ),
-        vol.Required(
-                CONF_CONFIG_CALIBRATE_APPLY,
-                default=data[CONF_CONFIG_CALIBRATE_APPLY]):
-                    selector.SelectSelector(
-                    selector.SelectSelectorConfig(
+            vol.Optional(
+                CONF_CONFIG_CALIBRATE_VALUE, default=data[CONF_CONFIG_CALIBRATE_VALUE]
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    mode=selector.NumberSelectorMode.BOX,
+                    step="any",
+                ),
+            ),
+            vol.Required(
+                CONF_CONFIG_CALIBRATE_APPLY, default=data[CONF_CONFIG_CALIBRATE_APPLY]
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
                     options=data.get(CONF_METER_TYPE, []),
                     translation_key=CONF_METER_TYPE,
                     mode=selector.SelectSelectorMode.DROPDOWN,
-                    custom_value =False,
-                    multiple=False
+                    custom_value=False,
+                    multiple=False,
                 ),
             ),
         }
@@ -623,33 +651,34 @@ def create_multi_option_schema_step_2(data):
         multi_option_calc = {
             vol.Required(
                 CONF_SOURCE_CALC_MULTIPLIER, data[CONF_SOURCE_CALC_MULTIPLIER]
-                ): selector.NumberSelector(
+            ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     mode=selector.NumberSelectorMode.BOX,
                     step="any",
-                    ),
                 ),
+            ),
             vol.Optional(
                 CONF_CONFIG_CALIBRATE_CALC_VALUE,
-                default=data.get(CONF_CONFIG_CALIBRATE_CALC_VALUE,0)): selector.NumberSelector(
+                default=data.get(CONF_CONFIG_CALIBRATE_CALC_VALUE, 0),
+            ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     mode=selector.NumberSelectorMode.BOX,
                     step="any",
-                    ),
                 ),
+            ),
             vol.Required(
                 CONF_CONFIG_CALIBRATE_CALC_APPLY,
-                    default=data.get(CONF_CONFIG_CALIBRATE_CALC_APPLY, [])):
-                    selector.SelectSelector(
-                    selector.SelectSelectorConfig(
+                default=data.get(CONF_CONFIG_CALIBRATE_CALC_APPLY, []),
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
                     options=data.get(CONF_METER_TYPE, []),
                     translation_key=CONF_METER_TYPE,
                     mode=selector.SelectSelectorMode.DROPDOWN,
-                    custom_value =False,
-                    multiple=False
-                    ),
+                    custom_value=False,
+                    multiple=False,
                 ),
-            }
+            ),
+        }
     else:
         multi_option_calc = {}
 
@@ -673,8 +702,9 @@ def create_multi_option_schema_step_2(data):
         ): selector.BooleanSelector(),
     }
     return vol.Schema(
-        {**create_multi_option_schema_step_1(data).schema,
-         **multi_option_step_2.schema,
+        {
+            **create_multi_option_schema_step_1(data).schema,
+            **multi_option_step_2.schema,
             **multi_option_calc,
             **multi_option_common,
         }

--- a/custom_components/utility_meter_next_gen/select.py
+++ b/custom_components/utility_meter_next_gen/select.py
@@ -9,8 +9,8 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_UNIQUE_ID
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device import async_device_info_to_link_from_entity
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device import async_entity_id_to_device
+from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -31,7 +31,7 @@ async def async_setup_entry(
 
     unique_id = config_entry.entry_id
 
-    device_info = async_device_info_to_link_from_entity(
+    device = async_entity_id_to_device(
         hass,
         config_entry.options[CONF_SOURCE_SENSOR],
     )
@@ -40,7 +40,7 @@ async def async_setup_entry(
         name=name,
         tariffs=tariffs,
         unique_id=unique_id,
-        device_info=device_info,
+        device=device,
     )
     async_add_entities([tariff_select])
 
@@ -89,14 +89,14 @@ class TariffSelect(SelectEntity, RestoreEntity):
         *,
         yaml_slug: str | None = None,
         unique_id: str | None = None,
-        device_info: DeviceInfo | None = None,
+        device: DeviceEntry | None = None,
     ) -> None:
         """Initialize a tariff selector."""
         self._attr_name = name
         if yaml_slug:  # Backwards compatibility with YAML configuration entries
             self.entity_id = f"select.{yaml_slug}"
         self._attr_unique_id = unique_id
-        self._attr_device_info = device_info
+        self.device_entry = device
         self._current_tariff: str | None = None
         self._tariffs = tariffs
         self._attr_should_poll = False
@@ -105,12 +105,12 @@ class TariffSelect(SelectEntity, RestoreEntity):
     def options(self) -> list[str]:
         """Return the available tariffs."""
         tariff_options = list(self._tariffs)
-        #if "total" in tariff_options:
+        # if "total" in tariff_options:
         if any(t.lower() == "total" for t in tariff_options):
-            _LOGGER.debug(
-                "removing 'total' from select entity. "
-            )
-            tariff_options = [t for t in tariff_options if not re.fullmatch("total", t, re.IGNORECASE)]
+            _LOGGER.debug("removing 'total' from select entity. ")
+            tariff_options = [
+                t for t in tariff_options if not re.fullmatch("total", t, re.IGNORECASE)
+            ]
         return tariff_options
 
     @property

--- a/custom_components/utility_meter_next_gen/sensor.py
+++ b/custom_components/utility_meter_next_gen/sensor.py
@@ -28,7 +28,6 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_NAME,
     CONF_UNIQUE_ID,
-    CURRENCY_DOLLAR,
     EVENT_CORE_CONFIG_UPDATE,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
@@ -41,7 +40,8 @@ from homeassistant.core import (
     callback,
 )
 from homeassistant.helpers import entity_platform, entity_registry as er
-from homeassistant.helpers.device import async_device_info_to_link_from_entity
+from homeassistant.helpers.device import async_entity_id_to_device
+from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import (
@@ -55,9 +55,7 @@ from homeassistant.util import dt as dt_util, slugify
 from homeassistant.util.enum import try_parse_enum
 
 try:
-    from homeassistant.helpers.template.extensions.type_cast import (
-        TypeCastExtension,
-    )
+    from homeassistant.helpers.template.extensions.type_cast import TypeCastExtension
 
     is_number = TypeCastExtension.is_number
 except ImportError:
@@ -125,6 +123,7 @@ def clean_string(input_string):
     # Convert to lowercase
     return result.lower()
 
+
 def clean_string_display(input_string):
     """Replace non-alphanumeric characters with underscores."""
     result = re.sub(r"[^a-zA-Z0-9]", " ", input_string)
@@ -132,6 +131,7 @@ def clean_string_display(input_string):
     result = re.sub(r" +", " ", result)
     # Convert to lowercase
     return result.title()
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -145,7 +145,7 @@ async def async_setup_entry(
     source_entity_id = er.async_validate_entity_id(
         registry, config_entry.options[CONF_SOURCE_SENSOR]
     )
-    device_info = async_device_info_to_link_from_entity(
+    device = async_entity_id_to_device(
         hass,
         source_entity_id,
     )
@@ -155,8 +155,12 @@ async def async_setup_entry(
         )
     else:
         source_calc_entity_id = None
-    calibrate_calc_apply = config_entry.options.get(CONF_CONFIG_CALIBRATE_CALC_APPLY, None)
-    calibrate_calc_value = config_entry.options.get(CONF_CONFIG_CALIBRATE_CALC_VALUE, Decimal(0))
+    calibrate_calc_apply = config_entry.options.get(
+        CONF_CONFIG_CALIBRATE_CALC_APPLY, None
+    )
+    calibrate_calc_value = config_entry.options.get(
+        CONF_CONFIG_CALIBRATE_CALC_VALUE, Decimal(0)
+    )
     calibrate_apply = config_entry.options.get(CONF_CONFIG_CALIBRATE_APPLY, None)
     calibrate_value = config_entry.options.get(CONF_CONFIG_CALIBRATE_VALUE, Decimal(0))
     create_calc_sensor = config_entry.options[CONF_CREATE_CALCULATION_SENSOR]
@@ -179,7 +183,11 @@ async def async_setup_entry(
     calc_sensors = []
     tariffs = config_entry.options[CONF_TARIFFS]
 
-    if meter_type is not None and not isinstance(meter_type, str) and len(meter_type) > 1:
+    if (
+        meter_type is not None
+        and not isinstance(meter_type, str)
+        and len(meter_type) > 1
+    ):
         for meter in meter_type:
             if not tariffs:
                 # Add single sensor, not gated by a tariff selector
@@ -194,7 +202,7 @@ async def async_setup_entry(
                     ),
                     cron_pattern=cron_pattern,
                     delta_values=delta_values,
-                    device_info=device_info,
+                    device=device,
                     meter_offset=meter_offset,
                     meter_type=meter,
                     name=f"{name} {METER_NAME_TYPES[meter]}",
@@ -225,7 +233,7 @@ async def async_setup_entry(
                         ),
                         cron_pattern=cron_pattern,
                         device_class=None,
-                        device_info=device_info,
+                        device=device,
                         entity_id=(
                             f"sensor.{clean_string(name)}_{clean_string(METER_NAME_TYPES[meter])}"
                         ),
@@ -259,7 +267,7 @@ async def async_setup_entry(
                         ),
                         cron_pattern=cron_pattern,
                         delta_values=delta_values,
-                        device_info=device_info,
+                        device=device,
                         meter_offset=meter_offset,
                         meter_type=meter,
                         name=f"{name} {METER_NAME_TYPES[meter]} {tariff}",
@@ -289,7 +297,7 @@ async def async_setup_entry(
                             ),
                             cron_pattern=cron_pattern,
                             device_class=None,
-                            device_info=device_info,
+                            device=device,
                             entity_id=(
                                 f"sensor.{clean_string(name)}_{clean_string(METER_NAME_TYPES[meter])}_{clean_string(tariff)}"
                             ),
@@ -309,7 +317,7 @@ async def async_setup_entry(
                             calc_sensor
                         )
 
-    else: # noqa: PLR5501
+    else:  # noqa: PLR5501
         if not tariffs:
             # Add single sensor, not gated by a tariff selector
             meter_sensor = UtilityMeterSensor(
@@ -317,7 +325,7 @@ async def async_setup_entry(
                 calibrate_value=calibrate_value,
                 cron_pattern=cron_pattern,
                 delta_values=delta_values,
-                device_info=device_info,
+                device=device,
                 meter_offset=meter_offset,
                 meter_type=meter_type,
                 name=name,
@@ -342,7 +350,7 @@ async def async_setup_entry(
                     calibrate_calc_value=calibrate_calc_value,
                     cron_pattern=cron_pattern,
                     device_class=None,
-                    device_info=device_info,
+                    device=device,
                     entity_id=f"sensor.{clean_string(name)}",
                     hass=hass,
                     icon=None,
@@ -368,7 +376,7 @@ async def async_setup_entry(
                     calibrate_value=calibrate_value,
                     cron_pattern=cron_pattern,
                     delta_values=delta_values,
-                    device_info=device_info,
+                    device=device,
                     meter_offset=meter_offset,
                     meter_type=meter_type,
                     name=f"{name} {tariff}",
@@ -394,7 +402,7 @@ async def async_setup_entry(
                         calibrate_calc_value=calibrate_calc_value,
                         cron_pattern=cron_pattern,
                         device_class=None,  # device_class,
-                        device_info=device_info,
+                        device=device,
                         entity_id=f"sensor.{clean_string(name)}_{clean_string(tariff)}",
                         hass=hass,
                         icon=None,
@@ -529,7 +537,6 @@ class UtilitySensorExtraStoredData(SensorExtraStoredData):
     calculated_current_value: Decimal | None
     calculated_last_value: Decimal | None
 
-
     def as_dict(self) -> dict[str, Any]:
         """Return a dict representation of the utility sensor data."""
         data = super().as_dict()
@@ -632,11 +639,11 @@ class UtilityMeterSensor(RestoreSensor):
         unique_id,
         sensor_always_available,
         suggested_entity_id=None,
-        device_info=None,
+        device: DeviceEntry | None = None,
     ):
         """Initialize the Utility Meter sensor."""
         self._attr_unique_id = unique_id
-        self._attr_device_info = device_info
+        self.device_entry = device
         self.entity_id = suggested_entity_id
         self._parent_meter = parent_meter
         self._sensor_source_id = source_entity
@@ -679,9 +686,7 @@ class UtilityMeterSensor(RestoreSensor):
         self.scheduler = (
             CronSim(
                 self._cron_pattern,
-                dt_util.now(
-                    dt_util.get_default_time_zone()
-                ),
+                dt_util.now(dt_util.get_default_time_zone()),
             )
             if self._cron_pattern
             else None
@@ -692,9 +697,7 @@ class UtilityMeterSensor(RestoreSensor):
         self._input_device_class = attributes.get(ATTR_DEVICE_CLASS)
         self._attr_native_unit_of_measurement = attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         self._attr_native_value = Decimal(self._calibrate_value)
-        self._attr_calculated_current_value = Decimal(
-            self._calibrate_calc_value
-        )
+        self._attr_calculated_current_value = Decimal(self._calibrate_calc_value)
         self.async_write_ha_state()
 
     @staticmethod
@@ -768,9 +771,10 @@ class UtilityMeterSensor(RestoreSensor):
             return
 
         if self.native_value is None:
-            _LOGGER.debug("selfHassDATA: %s",self.hass.data[DATA_UTILITY][self._parent_meter][
-                DATA_TARIFF_SENSORS
-            ])
+            _LOGGER.debug(
+                "selfHassDATA: %s",
+                self.hass.data[DATA_UTILITY][self._parent_meter][DATA_TARIFF_SENSORS],
+            )
             # First state update initializes the utility_meter sensors
             for sensor in self.hass.data[DATA_UTILITY][self._parent_meter][
                 DATA_TARIFF_SENSORS
@@ -787,7 +791,9 @@ class UtilityMeterSensor(RestoreSensor):
             adjustment := self.calculate_adjustment(old_state, new_state)
         ) is not None and (self._sensor_net_consumption or adjustment >= 0):
             # If net_consumption is off, the adjustment must be non-negative
-            _LOGGER.debug("%s: Adjustment Check:  %s : %s", self.name, adjustment, self._tariff)
+            _LOGGER.debug(
+                "%s: Adjustment Check:  %s : %s", self.name, adjustment, self._tariff
+            )
             self._attr_native_value += Decimal(adjustment)  # type: ignore[operator]
 
             if (
@@ -955,10 +961,13 @@ class UtilityMeterSensor(RestoreSensor):
         @callback
         def async_source_tracking(event):
             """Wait for source to be ready, then start meter."""
-            if str(self._tariff).lower() != TOTAL_TARIFF and self._tariff_entity is not None:
+            if (
+                str(self._tariff).lower() != TOTAL_TARIFF
+                and self._tariff_entity is not None
+            ):
                 # If the tariff is not TOTAL_TARIFF, we need to track the tariff entity
                 # and change the status of the utility meter sensor accordingly
-                #if self._tariff_entity is not None:
+                # if self._tariff_entity is not None:
                 _LOGGER.debug(
                     "<%s> tracks utility meter %s", self.name, self._tariff_entity
                 )
@@ -1095,6 +1104,7 @@ class UtilityMeterSensor(RestoreSensor):
             restored_last_extra_data.as_dict()
         )
 
+
 class UtilityMeterCalculatedSensor(RestoreSensor):
     """Representation of an Seperate Calculated sensor."""
 
@@ -1121,7 +1131,7 @@ class UtilityMeterCalculatedSensor(RestoreSensor):
         calibrate_calc_value: Decimal,
         cron_pattern: str | None,
         device_class: SensorDeviceClass | None,
-        device_info,
+        device: DeviceEntry | None,
         entity_id: str,
         icon: str | None,
         meter_type: str | None,
@@ -1132,14 +1142,13 @@ class UtilityMeterCalculatedSensor(RestoreSensor):
         tariff: str | None,
         unique_id: str | None,
         uom: str | None,
-
     ) -> None:
         """Initialize the sensor."""
         self._attr_collecting_status = None
         self._attr_device_class = (
             SensorDeviceClass.MONETARY if device_class is None else device_class
         )
-        self._attr_device_info = device_info
+        self.device_entry = device
         _currency_icons = {
             "EUR": "mdi:currency-eur",
             "GBP": "mdi:currency-gbp",
@@ -1152,9 +1161,13 @@ class UtilityMeterCalculatedSensor(RestoreSensor):
             "TRY": "mdi:currency-try",
             "BRL": "mdi:currency-brl",
         }
-        self._attr_icon = icon if icon is not None else _currency_icons.get(hass.config.currency, "")
+        self._attr_icon = (
+            icon if icon is not None else _currency_icons.get(hass.config.currency, "")
+        )
         self._attr_name = name
-        self._attr_native_unit_of_measurement = hass.config.currency if uom is None else uom
+        self._attr_native_unit_of_measurement = (
+            hass.config.currency if uom is None else uom
+        )
         self._attr_suggested_display_precision = PRECISION
         self._attr_state_class = (
             SensorStateClass.TOTAL if state_class is None else state_class
@@ -1184,7 +1197,7 @@ class UtilityMeterCalculatedSensor(RestoreSensor):
                 # e.g. "€/kWh" → take the currency part before "/"
                 if "/" in calc_uom:
                     self._attr_native_unit_of_measurement = calc_uom.split("/")[0]
-        
+
         self.async_on_remove(
             async_track_state_change_event(
                 self.hass, self._entity_id, self._async_attribute_sensor_state_listener
@@ -1253,7 +1266,7 @@ class UtilityMeterCalculatedSensor(RestoreSensor):
                     "State update for %s is None or unavailable, setting to STATE_UNAVAILABLE",
                     self._entity_id,
                 )
-                #self._attr_native_value = STATE_UNAVAILABLE #Decimal(0)
+                # self._attr_native_value = STATE_UNAVAILABLE #Decimal(0)
                 self._attr_collecting_status = STATE_UNAVAILABLE
                 self.async_write_ha_state()
             return

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
     "name": "Utility Meter Next Gen",
-    "homeassistant": "2025.2.4",
+    "homeassistant": "2026.8.0",
     "hacs": "2.0.1",
     "render_readme": true,
     "zip_release": true,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.12.0
-homeassistant>=2025.2.4
+homeassistant>=2026.8.0
 pip>=26.2
 ruff==0.16.1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Utility Meter Next Gen."""

--- a/tests/components/utility_meter_evolved/__snapshots__/test_diagnostics.ambr
+++ b/tests/components/utility_meter_evolved/__snapshots__/test_diagnostics.ambr
@@ -1,0 +1,89 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'config_entry': dict({
+      'data': dict({
+      }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'utility_meter',
+      'minor_version': 2,
+      'options': dict({
+        'cycle': 'monthly',
+        'delta_values': False,
+        'name': 'Energy Bill',
+        'net_consumption': False,
+        'offset': 0,
+        'periodically_resetting': True,
+        'source': 'sensor.input1',
+        'tariffs': list([
+          'tariff0',
+          'tariff1',
+        ]),
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'subentries': list([
+      ]),
+      'title': 'Energy Bill',
+      'unique_id': None,
+      'version': 2,
+    }),
+    'tariff_sensors': list([
+      dict({
+        'cron': '0 0 1 * *',
+        'entity_id': 'sensor.energy_bill_tariff0',
+        'extra_attributes': dict({
+          'last_period': '0',
+          'last_reset': '2024-04-05T00:00:00+00:00',
+          'last_valid_state': 'None',
+          'next_reset': '2024-05-01T00:00:00-07:00',
+          'status': 'collecting',
+          'tariff': 'tariff0',
+        }),
+        'last_sensor_data': dict({
+          'last_period': '0',
+          'last_reset': '2024-04-05T00:00:00+00:00',
+          'last_valid_state': 3,
+          'native_unit_of_measurement': 'kWh',
+          'native_value': dict({
+            '__type': "<class 'decimal.Decimal'>",
+            'decimal_str': '3',
+          }),
+          'status': 'collecting',
+        }),
+        'name': 'Energy Bill tariff0',
+        'period': 'monthly',
+        'source': 'sensor.input1',
+      }),
+      dict({
+        'cron': '0 0 1 * *',
+        'entity_id': 'sensor.energy_bill_tariff1',
+        'extra_attributes': dict({
+          'last_period': '0',
+          'last_reset': '2024-04-05T00:00:00+00:00',
+          'last_valid_state': 'None',
+          'next_reset': '2024-05-01T00:00:00-07:00',
+          'status': 'paused',
+          'tariff': 'tariff1',
+        }),
+        'last_sensor_data': dict({
+          'last_period': '0',
+          'last_reset': '2024-04-05T00:00:00+00:00',
+          'last_valid_state': 7,
+          'native_unit_of_measurement': 'kWh',
+          'native_value': dict({
+            '__type': "<class 'decimal.Decimal'>",
+            'decimal_str': '7',
+          }),
+          'status': 'paused',
+        }),
+        'name': 'Energy Bill tariff1',
+        'period': 'monthly',
+        'source': 'sensor.input1',
+      }),
+    ]),
+  })
+# ---

--- a/tests/components/utility_meter_evolved/test_config_flow.py
+++ b/tests/components/utility_meter_evolved/test_config_flow.py
@@ -10,7 +10,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from tests.common import MockConfigEntry, get_schema_suggested_value
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    get_schema_suggested_value,
+)
 
 
 @pytest.mark.parametrize("platform", ["sensor"])
@@ -328,7 +331,7 @@ async def test_change_device_source(
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test remove the device registry configuration entry when the source entity changes."""
+    """Test helper entities relink when the configured source changes."""
     # Configure source entity 1 (with a linked device)
     source_config_entry_1 = MockConfigEntry()
     source_config_entry_1.add_to_hass(hass)
@@ -403,11 +406,12 @@ async def test_change_device_source(
     assert await hass.config_entries.async_setup(utility_meter_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    # Confirm that the configuration entry has been added to the source entity 1 (current) device registry
+    # The helper entity links to source 1 without owning its device.
     current_device = device_registry.async_get(
         device_id=current_entity_source.device_id
     )
-    assert utility_meter_config_entry.entry_id in current_device.config_entries
+    assert utility_meter_config_entry.entry_id not in current_device.config_entries
+    assert entity_registry.async_get("sensor.energy").device_id == current_device.id
 
     # Change configuration options to use source entity 2 (with a linked device) and reload the integration
     previous_entity_source = source_entity_1
@@ -427,17 +431,18 @@ async def test_change_device_source(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
 
-    # Confirm that the configuration entry has been removed from the source entity 1 (previous) device registry
+    # Source 1 retains its original owner.
     previous_device = device_registry.async_get(
         device_id=previous_entity_source.device_id
     )
     assert utility_meter_config_entry.entry_id not in previous_device.config_entries
 
-    # Confirm that the configuration entry has been added to the source entity 2 (current) device registry
+    # The helper entity now links to source 2 without owning its device.
     current_device = device_registry.async_get(
         device_id=current_entity_source.device_id
     )
-    assert utility_meter_config_entry.entry_id in current_device.config_entries
+    assert utility_meter_config_entry.entry_id not in current_device.config_entries
+    assert entity_registry.async_get("sensor.energy").device_id == current_device.id
 
     # Change configuration options to use source entity 3 (without a device) and reload the integration
     previous_entity_source = source_entity_2
@@ -457,13 +462,14 @@ async def test_change_device_source(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
 
-    # Confirm that the configuration entry has been removed from the source entity 2 (previous) device registry
+    # Source 2 retains its original owner.
     previous_device = device_registry.async_get(
         device_id=previous_entity_source.device_id
     )
     assert utility_meter_config_entry.entry_id not in previous_device.config_entries
 
-    # Confirm that there is no device with the helper configuration entry
+    # A source without a device leaves the helper entity detached.
+    assert entity_registry.async_get("sensor.energy").device_id is None
     assert (
         dr.async_entries_for_config_entry(
             device_registry, utility_meter_config_entry.entry_id
@@ -489,8 +495,9 @@ async def test_change_device_source(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
 
-    # Confirm that the configuration entry has been added to the source entity 2 (current) device registry
+    # The helper entity links back to source 2 without taking ownership.
     current_device = device_registry.async_get(
         device_id=current_entity_source.device_id
     )
-    assert utility_meter_config_entry.entry_id in current_device.config_entries
+    assert utility_meter_config_entry.entry_id not in current_device.config_entries
+    assert entity_registry.async_get("sensor.energy").device_id == current_device.id

--- a/tests/components/utility_meter_evolved/test_device_management.py
+++ b/tests/components/utility_meter_evolved/test_device_management.py
@@ -1,0 +1,315 @@
+"""Tests for Utility Meter Next Gen device management."""
+
+from collections.abc import Iterable
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from custom_components import utility_meter_next_gen as integration
+from custom_components.utility_meter_next_gen import async_migrate_entry
+from custom_components.utility_meter_next_gen.config_flow import (
+    UtilityMeterEvolvedCustomConfigFlow,
+)
+from custom_components.utility_meter_next_gen.const import (
+    CONF_CONFIG_CALIBRATE_APPLY,
+    CONF_CONFIG_CALIBRATE_CALC_APPLY,
+    CONF_CONFIG_CALIBRATE_CALC_VALUE,
+    CONF_CONFIG_CALIBRATE_VALUE,
+    CONF_CONFIG_PREDEFINED,
+    CONF_CONFIG_TYPE,
+    CONF_CREATE_CALCULATION_SENSOR,
+    CONF_CRON_PATTERN,
+    CONF_METER_DELTA_VALUES,
+    CONF_METER_NET_CONSUMPTION,
+    CONF_METER_OFFSET,
+    CONF_METER_PERIODICALLY_RESETTING,
+    CONF_METER_TYPE,
+    CONF_SENSOR_ALWAYS_AVAILABLE,
+    CONF_SOURCE_CALC_MULTIPLIER,
+    CONF_SOURCE_CALC_SENSOR,
+    CONF_SOURCE_SENSOR,
+    CONF_TARIFFS,
+    DOMAIN,
+    MONTHLY,
+)
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+
+def _options(source_entity_id: str, tariffs: Iterable[str] = ()) -> dict[str, Any]:
+    """Return a complete set of config entry options."""
+    return {
+        CONF_CONFIG_CALIBRATE_APPLY: None,
+        CONF_CONFIG_CALIBRATE_CALC_APPLY: None,
+        CONF_CONFIG_CALIBRATE_CALC_VALUE: 0,
+        CONF_CONFIG_CALIBRATE_VALUE: 0,
+        CONF_CONFIG_TYPE: CONF_CONFIG_PREDEFINED,
+        CONF_CREATE_CALCULATION_SENSOR: False,
+        CONF_CRON_PATTERN: None,
+        CONF_METER_DELTA_VALUES: False,
+        CONF_METER_NET_CONSUMPTION: False,
+        CONF_METER_OFFSET: {"days": 0, "hours": 0, "minutes": 0, "seconds": 0},
+        CONF_METER_PERIODICALLY_RESETTING: True,
+        CONF_METER_TYPE: MONTHLY,
+        CONF_SENSOR_ALWAYS_AVAILABLE: False,
+        CONF_SOURCE_CALC_MULTIPLIER: 1,
+        CONF_SOURCE_CALC_SENSOR: None,
+        CONF_SOURCE_SENSOR: source_entity_id,
+        CONF_TARIFFS: list(tariffs),
+    }
+
+
+def _add_source(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    unique_id: str,
+) -> tuple[MockConfigEntry, dr.DeviceEntry, er.RegistryEntry]:
+    """Add a source config entry, device, and sensor entity."""
+    source_entry = MockConfigEntry(domain="test")
+    source_entry.add_to_hass(hass)
+    source_device = device_registry.async_get_or_create(
+        config_entry_id=source_entry.entry_id,
+        identifiers={("test", unique_id)},
+    )
+    source_entity = entity_registry.async_get_or_create(
+        "sensor",
+        "test",
+        unique_id,
+        config_entry=source_entry,
+        device_id=source_device.id,
+    )
+    return source_entry, source_device, source_entity
+
+
+def _helper_entities(
+    entity_registry: er.EntityRegistry, entry: ConfigEntry
+) -> list[er.RegistryEntry]:
+    """Return all entities belonging to a helper config entry."""
+    return list(
+        entity_registry.entities.get_entries_for_config_entry_id(entry.entry_id)
+    )
+
+
+@pytest.mark.parametrize(
+    ("tariffs", "expected_entity_count"),
+    [([], 1), (["peak", "offpeak"], 3)],
+)
+async def test_entities_link_without_owning_source_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    tariffs: list[str],
+    expected_entity_count: int,
+) -> None:
+    """Entities link to the source device without adding helper ownership."""
+    source_entry, source_device, source_entity = _add_source(
+        hass, device_registry, entity_registry, "source"
+    )
+    helper_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options=_options(source_entity.entity_id, tariffs),
+        title="Energy meter",
+        version=UtilityMeterEvolvedCustomConfigFlow.VERSION,
+        minor_version=UtilityMeterEvolvedCustomConfigFlow.MINOR_VERSION,
+    )
+    helper_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(helper_entry.entry_id)
+    await hass.async_block_till_done()
+
+    helper_entities = _helper_entities(entity_registry, helper_entry)
+    assert len(helper_entities) == expected_entity_count
+    assert {entity.device_id for entity in helper_entities} == {source_device.id}
+
+    source_device = device_registry.async_get(source_device.id)
+    assert source_device is not None
+    assert source_device.config_entries == {source_entry.entry_id}
+    assert (
+        dr.async_entries_for_config_entry(device_registry, helper_entry.entry_id) == []
+    )
+
+
+async def test_source_option_change_relinks_entities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Changing the source relinks helper entities and preserves device ownership."""
+    source_entry_1, source_device_1, source_entity_1 = _add_source(
+        hass, device_registry, entity_registry, "source_1"
+    )
+    source_entry_2, source_device_2, source_entity_2 = _add_source(
+        hass, device_registry, entity_registry, "source_2"
+    )
+    helper_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options=_options(source_entity_1.entity_id, ["peak", "offpeak"]),
+        title="Energy meter",
+        version=UtilityMeterEvolvedCustomConfigFlow.VERSION,
+        minor_version=UtilityMeterEvolvedCustomConfigFlow.MINOR_VERSION,
+    )
+    helper_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(helper_entry.entry_id)
+    await hass.async_block_till_done()
+
+    hass.config_entries.async_update_entry(
+        helper_entry,
+        options=_options(source_entity_2.entity_id, ["peak", "offpeak"]),
+    )
+    await hass.async_block_till_done()
+
+    assert {
+        entity.device_id for entity in _helper_entities(entity_registry, helper_entry)
+    } == {source_device_2.id}
+    assert device_registry.async_get(source_device_1.id).config_entries == {
+        source_entry_1.entry_id
+    }
+    assert device_registry.async_get(source_device_2.id).config_entries == {
+        source_entry_2.entry_id
+    }
+    assert (
+        dr.async_entries_for_config_entry(device_registry, helper_entry.entry_id) == []
+    )
+
+
+async def test_source_entity_removal_detaches_helper_entities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Removing the source entity detaches, but does not remove, helper entities."""
+    _, _, source_entity = _add_source(hass, device_registry, entity_registry, "source")
+    helper_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options=_options(source_entity.entity_id, ["peak", "offpeak"]),
+        title="Energy meter",
+        version=UtilityMeterEvolvedCustomConfigFlow.VERSION,
+        minor_version=UtilityMeterEvolvedCustomConfigFlow.MINOR_VERSION,
+    )
+    helper_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(helper_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_registry.async_remove(source_entity.entity_id)
+    await hass.async_block_till_done()
+
+    helper_entities = _helper_entities(entity_registry, helper_entry)
+    assert len(helper_entities) == 3
+    assert {entity.device_id for entity in helper_entities} == {None}
+    assert helper_entry.entry_id in hass.config_entries.async_entry_ids()
+
+
+async def test_source_entity_rename_updates_entry_once(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Renaming the source updates the option without scheduling duplicate reloads."""
+    _, source_device, source_entity = _add_source(
+        hass, device_registry, entity_registry, "source"
+    )
+    helper_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options=_options(source_entity.entity_id),
+        title="Energy meter",
+        version=UtilityMeterEvolvedCustomConfigFlow.VERSION,
+        minor_version=UtilityMeterEvolvedCustomConfigFlow.MINOR_VERSION,
+    )
+    helper_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(helper_entry.entry_id)
+    await hass.async_block_till_done()
+
+    with patch(
+        "custom_components.utility_meter_next_gen.async_unload_entry",
+        wraps=integration.async_unload_entry,
+    ) as mock_unload_entry:
+        entity_registry.async_update_entity(
+            source_entity.entity_id,
+            new_entity_id="sensor.renamed_source",
+        )
+        await hass.async_block_till_done()
+
+    assert mock_unload_entry.call_count == 1
+    assert helper_entry.options[CONF_SOURCE_SENSOR] == "sensor.renamed_source"
+    assert {
+        entity.device_id for entity in _helper_entities(entity_registry, helper_entry)
+    } == {source_device.id}
+
+
+async def test_device_model_migration_removes_all_legacy_devices(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Migration removes stale helper-owned devices and relinks their entities."""
+    source_entry, source_device, source_entity = _add_source(
+        hass, device_registry, entity_registry, "current_source"
+    )
+    helper_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options=_options(source_entity.entity_id),
+        title="Energy meter",
+        version=UtilityMeterEvolvedCustomConfigFlow.VERSION,
+        minor_version=1,
+    )
+    helper_entry.add_to_hass(hass)
+
+    legacy_devices = [
+        device_registry.async_get_or_create(
+            config_entry_id=helper_entry.entry_id,
+            identifiers={("legacy", legacy_id)},
+        )
+        for legacy_id in ("old_source", "current_source")
+    ]
+    for index, legacy_device in enumerate(legacy_devices):
+        entity_registry.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            f"legacy_{index}",
+            config_entry=helper_entry,
+            device_id=legacy_device.id,
+        )
+
+    assert await async_migrate_entry(hass, helper_entry)
+
+    assert helper_entry.version == UtilityMeterEvolvedCustomConfigFlow.VERSION
+    assert (
+        helper_entry.minor_version == UtilityMeterEvolvedCustomConfigFlow.MINOR_VERSION
+    )
+    assert {
+        entity.device_id for entity in _helper_entities(entity_registry, helper_entry)
+    } == {source_device.id}
+    assert all(
+        device_registry.async_get(legacy_device.id) is None
+        for legacy_device in legacy_devices
+    )
+    source_device = device_registry.async_get(source_device.id)
+    assert source_device is not None
+    assert source_device.config_entries == {source_entry.entry_id}
+
+
+async def test_legacy_data_migration_preserves_both_calibration_values(
+    hass: HomeAssistant,
+) -> None:
+    """Version 3 migration retains both calibration defaults."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            CONF_SOURCE_SENSOR: "sensor.source",
+            CONF_SOURCE_CALC_MULTIPLIER: 1,
+        },
+        version=3,
+        minor_version=1,
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry)
+
+    assert entry.options[CONF_CONFIG_CALIBRATE_VALUE] == 0
+    assert entry.options[CONF_CONFIG_CALIBRATE_CALC_VALUE] == 0

--- a/tests/components/utility_meter_evolved/test_diagnostics.py
+++ b/tests/components/utility_meter_evolved/test_diagnostics.py
@@ -11,14 +11,16 @@ from homeassistant.components.utility_meter.const import DOMAIN
 from homeassistant.components.utility_meter.sensor import ATTR_LAST_RESET
 from homeassistant.core import HomeAssistant, State
 
-from tests.common import (
+from pytest_homeassistant_custom_component.common import (
     CLIENT_ID,
     MockConfigEntry,
     MockUser,
     mock_restore_cache_with_extra_data,
 )
-from tests.components.diagnostics import get_diagnostics_for_config_entry
-from tests.typing import ClientSessionGenerator
+from pytest_homeassistant_custom_component.components.diagnostics import (
+    get_diagnostics_for_config_entry,
+)
+from pytest_homeassistant_custom_component.typing import ClientSessionGenerator
 
 
 async def generate_new_hass_access_token(

--- a/tests/components/utility_meter_evolved/test_init.py
+++ b/tests/components/utility_meter_evolved/test_init.py
@@ -35,7 +35,10 @@ from homeassistant.helpers.event import async_track_entity_registry_updated_even
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry, mock_restore_cache
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    mock_restore_cache,
+)
 
 
 @pytest.fixture
@@ -530,95 +533,6 @@ async def test_setup_and_remove_config_entry(
     assert len(entity_registry.entities) == 0
 
 
-async def test_device_cleaning(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    """Test for source entity device for Utility Meter."""
-
-    # Source entity device config entry
-    source_config_entry = MockConfigEntry()
-    source_config_entry.add_to_hass(hass)
-
-    # Device entry of the source entity
-    source_device1_entry = device_registry.async_get_or_create(
-        config_entry_id=source_config_entry.entry_id,
-        identifiers={("sensor", "identifier_test1")},
-        connections={("mac", "30:31:32:33:34:01")},
-    )
-
-    # Source entity registry
-    source_entity = entity_registry.async_get_or_create(
-        "sensor",
-        "test",
-        "source",
-        config_entry=source_config_entry,
-        device_id=source_device1_entry.id,
-    )
-    await hass.async_block_till_done()
-    assert entity_registry.async_get("sensor.test_source") is not None
-
-    # Configure the configuration entry for Utility Meter
-    utility_meter_config_entry = MockConfigEntry(
-        data={},
-        domain=DOMAIN,
-        options={
-            "cycle": "monthly",
-            "delta_values": False,
-            "name": "Meter",
-            "net_consumption": False,
-            "offset": 0,
-            "periodically_resetting": True,
-            "source": "sensor.test_source",
-            "tariffs": [],
-        },
-        title="Meter",
-    )
-    utility_meter_config_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(utility_meter_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # Confirm the link between the source entity device and the meter sensor
-    utility_meter_entity = entity_registry.async_get("sensor.meter")
-    assert utility_meter_entity is not None
-    assert utility_meter_entity.device_id == source_entity.device_id
-
-    # Device entry incorrectly linked to Utility Meter config entry
-    device_registry.async_get_or_create(
-        config_entry_id=utility_meter_config_entry.entry_id,
-        identifiers={("sensor", "identifier_test2")},
-        connections={("mac", "30:31:32:33:34:02")},
-    )
-    device_registry.async_get_or_create(
-        config_entry_id=utility_meter_config_entry.entry_id,
-        identifiers={("sensor", "identifier_test3")},
-        connections={("mac", "30:31:32:33:34:03")},
-    )
-    await hass.async_block_till_done()
-
-    # Before reloading the config entry, two devices are expected to be linked
-    devices_before_reload = device_registry.devices.get_devices_for_config_entry_id(
-        utility_meter_config_entry.entry_id
-    )
-    assert len(devices_before_reload) == 3
-
-    # Config entry reload
-    await hass.config_entries.async_reload(utility_meter_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # Confirm the link between the source entity device and the meter sensor after reload
-    utility_meter_entity = entity_registry.async_get("sensor.meter")
-    assert utility_meter_entity is not None
-    assert utility_meter_entity.device_id == source_entity.device_id
-
-    # After reloading the config entry, only one linked device is expected
-    devices_after_reload = device_registry.devices.get_devices_for_config_entry_id(
-        utility_meter_config_entry.entry_id
-    )
-    assert len(devices_after_reload) == 1
-
-
 @pytest.mark.parametrize(
     ("tariffs", "expected_entities"),
     [
@@ -643,7 +557,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     sensor_entity_entry: er.RegistryEntry,
     expected_entities: set[str],
 ) -> None:
-    """Test the utility_meter config entry is removed when the source entity is removed."""
+    """Test helper entities detach when the source entity is removed."""
     # Add another config entry to the sensor device
     other_config_entry = MockConfigEntry()
     other_config_entry.add_to_hass(hass)
@@ -667,7 +581,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert set(events) == expected_entities
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert utility_meter_config_entry.entry_id in sensor_device.config_entries
+    assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
 
     # Remove the source sensor's config entry from the device, this removes the
     # source sensor
@@ -682,7 +596,15 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
         await hass.async_block_till_done()
     mock_unload_entry.assert_not_called()
 
-    # Check that the utility_meter config entry is removed from the device
+    # The helper entities detach from the source device.
+    for (
+        utility_meter_entity
+    ) in entity_registry.entities.get_entries_for_config_entry_id(
+        utility_meter_config_entry.entry_id
+    ):
+        assert utility_meter_entity.device_id is None
+
+    # The source device remains solely owned by the other config entry.
     sensor_device = device_registry.async_get(sensor_device.id)
     assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
 
@@ -734,7 +656,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert set(events) == expected_entities
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert utility_meter_config_entry.entry_id in sensor_device.config_entries
+    assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
 
     # Remove the source sensor from the device
     with patch(
@@ -747,7 +669,15 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
         await hass.async_block_till_done()
     mock_unload_entry.assert_called_once()
 
-    # Check that the utility_meter config entry is removed from the device
+    # The helper entities detach from the source device.
+    for (
+        utility_meter_entity
+    ) in entity_registry.entities.get_entries_for_config_entry_id(
+        utility_meter_config_entry.entry_id
+    ):
+        assert utility_meter_entity.device_id is None
+
+    # The helper never owns the source device.
     sensor_device = device_registry.async_get(sensor_device.id)
     assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
 
@@ -805,7 +735,7 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert set(events) == expected_entities
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert utility_meter_config_entry.entry_id in sensor_device.config_entries
+    assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
     sensor_device_2 = device_registry.async_get(sensor_device_2.id)
     assert utility_meter_config_entry.entry_id not in sensor_device_2.config_entries
 
@@ -820,11 +750,19 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
         await hass.async_block_till_done()
     mock_unload_entry.assert_called_once()
 
-    # Check that the utility_meter config entry is moved to the other device
+    # The helper entities relink to the other device.
+    for (
+        utility_meter_entity
+    ) in entity_registry.entities.get_entries_for_config_entry_id(
+        utility_meter_config_entry.entry_id
+    ):
+        assert utility_meter_entity.device_id == sensor_device_2.id
+
+    # The helper does not own either source device.
     sensor_device = device_registry.async_get(sensor_device.id)
     assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
     sensor_device_2 = device_registry.async_get(sensor_device_2.id)
-    assert utility_meter_config_entry.entry_id in sensor_device_2.config_entries
+    assert utility_meter_config_entry.entry_id not in sensor_device_2.config_entries
 
     # Check that the utility_meter config entry is not removed
     assert utility_meter_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -874,7 +812,7 @@ async def test_async_handle_source_entity_new_entity_id(
     assert set(events) == expected_entities
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert utility_meter_config_entry.entry_id in sensor_device.config_entries
+    assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
 
     # Change the source entity's entity ID
     with patch(
@@ -890,9 +828,9 @@ async def test_async_handle_source_entity_new_entity_id(
     # Check that the utility_meter config entry is updated with the new entity ID
     assert utility_meter_config_entry.options["source"] == "sensor.new_entity_id"
 
-    # Check that the helper config is still in the device
+    # Renaming the source does not change device ownership.
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert utility_meter_config_entry.entry_id in sensor_device.config_entries
+    assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
 
     # Check that the utility_meter config entry is not removed
     assert utility_meter_config_entry.entry_id in hass.config_entries.async_entry_ids()

--- a/tests/components/utility_meter_evolved/test_select.py
+++ b/tests/components/utility_meter_evolved/test_select.py
@@ -5,7 +5,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 
 async def test_select_entity_name_config_entry(

--- a/tests/components/utility_meter_evolved/test_sensor.py
+++ b/tests/components/utility_meter_evolved/test_sensor.py
@@ -47,7 +47,7 @@ from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from tests.common import (
+from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
     async_fire_time_changed,
     mock_restore_cache_with_extra_data,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Shared fixtures for custom integration tests."""
+
+import pytest
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Allow tests to load integrations from the local custom_components folder."""
+    return enable_custom_integrations


### PR DESCRIPTION
## Summary
- replace deprecated implicit `DeviceInfo` linking with direct entity-to-source-device links
- migrate legacy helper-owned and duplicated devices to Home Assistant's single-config-entry ownership model
- preserve source rename, move, removal, and options-change behavior
- raise the minimum supported Home Assistant version to 2026.8.0
- expand device lifecycle and migration coverage and add tests/formatting to CI
- refresh compatibility and contributor documentation

## Why
Home Assistant 2026.8 changes devices to have a single config-entry owner. The previous helper APIs are deprecated and no longer provide the ownership/linking behavior this integration relied on.

## Validation
- 93 tests passed against the exact Home Assistant 2026.8.0 source tag
- 7 focused device-management tests passed
- Ruff lint and formatting checks passed
- Python compilation, JSON/YAML parsing, and Git whitespace checks passed

## Reviewer notes
The original request referenced Home Assistant 2028.8.0, but that release/tag does not exist. This PR targets the released 2026.8.0 version containing the relevant device-management changes.

## Summary by Sourcery

Adopt Home Assistant 2026.8’s single-owner device model by linking helper entities directly to their source devices, updating migrations, and tightening config/flow handling.

New Features:
- Add comprehensive device-management tests to validate helper entity linking, relinking, and detachment behavior across config and migration scenarios.
- Introduce project-level pytest configuration and shared fixtures for running Home Assistant custom component tests.

Bug Fixes:
- Ensure helper entities no longer take ownership of source devices, instead attaching to existing devices while preserving the source integration as sole owner.
- Fix calibration and migration logic so legacy entries correctly initialize and preserve both meter and calculation calibration defaults without data loss.
- Prevent duplicate config-entry reloads when source entities are renamed by tightening source change handling.

Enhancements:
- Refine config flow schemas and options handling, including minor versioning, to better support multi-step and multi-meter configurations.
- Rework config entry migration to a versioned, idempotent pipeline that also cleans up legacy helper-owned devices and relinks entities to their source devices.
- Align select and sensor entities with the new device model by replacing DeviceInfo-based linking with direct device references from source entities.
- Update diagnostics, selectors, and various helpers to use pytest-homeassistant-custom-component utilities and Home Assistant’s current helper APIs.
- Apply Ruff-based formatting and style cleanups across schemas, config flow, sensors, constants, and tests for consistency.

Build:
- Raise the minimum supported Home Assistant version to 2026.8.0 and bump the integration manifest version to 2026.8.0.
- Extend CI to run Ruff formatting checks and execute the pytest suite with pytest-homeassistant-custom-component and cronsim installed.

Documentation:
- Document the new Home Assistant compatibility requirements, device linking behavior, and contributor workflow using Ruff and pytest in README and CONTRIBUTING.